### PR TITLE
Alter Verbose/IsDebug output

### DIFF
--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -213,7 +213,7 @@ void Companion::ParseCurrentFileConfig(YAML::Node node) {
                 gCurrentFileOffset = segments[0][1].as<uint32_t>();
                 gCurrentCompressionType = GetCompressionType(this->gRomData, gCurrentFileOffset);
             } else {
-                throw std::runtime_error("Incorrect yaml syntax for segments.\n\nThe yaml expects:\n:config:\n  segments:\n  - [<segment>, <offset_of_compressed_file>]\n\nLike so:\nsegments:\n  - [0x06, 0x821D10]");
+                throw std::runtime_error("Incorrect yaml syntax for segments.\n\nThe yaml expects:\n:config:\n  segments:\n  - [<segment>, <file_offset>]\n\nLike so:\nsegments:\n  - [0x06, 0x821D10]");
             }
         }
 
@@ -226,7 +226,7 @@ void Companion::ParseCurrentFileConfig(YAML::Node node) {
                 this->gConfig.segment.local[id] = replacement;
                 SPDLOG_DEBUG("Segment {} replaced with 0x{:X}", id, replacement);
             } else {
-                throw std::runtime_error("Incorrect yaml syntax for segments.\n\nThe yaml expects:\n:config:\n  segments:\n  - [<segment>, <offset_of_compressed_file>]\n\nLike so:\nsegments:\n  - [0x06, 0x821D10]");
+                throw std::runtime_error("Incorrect yaml syntax for segments.\n\nThe yaml expects:\n:config:\n  segments:\n  - [<segment>, <file_offset>]\n\nLike so:\nsegments:\n  - [0x06, 0x821D10]");
             }
         }
     }
@@ -408,7 +408,7 @@ void Companion::Process() {
                     gCurrentFileOffset = segments[0][1].as<uint32_t>();
                     gCurrentCompressionType = GetCompressionType(this->gRomData, gCurrentFileOffset);
                 } else {
-                    throw std::runtime_error("Incorrect yaml syntax for segments.\n\nThe yaml expects:\n:config:\n  segments:\n  - [<segment>, <offset_of_compressed_file>]\n\nLike so:\nsegments:\n  - [0x06, 0x821D10]");
+                    throw std::runtime_error("Incorrect yaml syntax for segments.\n\nThe yaml expects:\n:config:\n  segments:\n  - [<segment>, <file_offset>]\n\nLike so:\nsegments:\n  - [0x06, 0x821D10]");
                 }
             }
         }

--- a/src/factories/DisplayListFactory.cpp
+++ b/src/factories/DisplayListFactory.cpp
@@ -123,7 +123,20 @@ void DListCodeExporter::Export(std::ostream &write, std::shared_ptr<IParsedData>
     gfxd_execute();
 
     write << std::string(out);
-    write << "}; // size = 0x" << std::hex << std::uppercase << (sizeof(uint32_t) * cmds.size()) << "\n\n";
+    write << "};\n";
+
+    if (Companion::Instance->IsDebug()) {
+
+        std::string str = ((sizeof(uint32_t) * cmds.size()) / 8) == 1 ? " displaylist" : " displaylists";
+
+        write << "// " << std::hex << std::uppercase << ((sizeof(uint32_t) * cmds.size()) / 8) << str << "\n";
+        if (IS_SEGMENTED(offset)) {
+            offset = SEGMENT_OFFSET(offset);
+        }
+        write << "// 0x" << std::hex << std::uppercase << (offset + (sizeof(uint32_t) * (cmds.size()))) << "\n";
+    }
+
+    write << "\n";
 }
 
 void DebugDisplayList(uint32_t w0, uint32_t w1){

--- a/src/factories/VtxFactory.cpp
+++ b/src/factories/VtxFactory.cpp
@@ -58,11 +58,14 @@ void VtxCodeExporter::Export(std::ostream &write, std::shared_ptr<IParsedData> r
         write << "{{{" << NUM(x) << ", " << NUM(y) << ", " << NUM(z) << "}, " << flag << ", {" << NUM(tc1) << ", " << NUM(tc2) << "}, {" << COL(c1) << ", " << COL(c2) << ", " << COL(c3) << ", " << COL(c4) << "}}},\n";
     }
 
+    write << "};\n";
+
     if (Companion::Instance->IsDebug()) {
-        write << fourSpaceTab << "// 0x" << std::hex << std::uppercase << (offset + (16 * vtx.size())) << "\n";
+        write << "// " << vtx.size() << " vertices\n";
+        write << "// 0x" << std::hex << std::uppercase << (offset + (sizeof(VtxRaw) * vtx.size())) << "\n";
     }
 
-    write << "}; // size = 0x" << std::hex << std::uppercase << (sizeof(VtxRaw) * vtx.size()) << "\n\n";
+    write << "\n";
 }
 
 void VtxBinaryExporter::Export(std::ostream &write, std::shared_ptr<IParsedData> raw, std::string& entryName, YAML::Node &node, std::string* replacement ) {


### PR DESCRIPTION
This PR makes it easier to compare the starts/ends of assets like so:

It also moves size into IsDebug so you can selectively add/remove that using the `-v` or `--verbose` command that Torch has.

![image](https://github.com/HarbourMasters/Torch/assets/7255464/30b95db8-b8b4-439e-b8c4-2bce2fe14354)


Also adds end addr output identical to the above to displaylists.

The idea is that, if the end addr matches the start addr. Then you're good. This change just makes that a little easier to see.