### PR TITLE
Fix lights bug for DisplaylistFactory

### DIFF
--- a/src/factories/DisplayListFactory.cpp
+++ b/src/factories/DisplayListFactory.cpp
@@ -373,8 +373,8 @@ std::optional<std::shared_ptr<IParsedData>> DListFactory::parse(std::vector<uint
 
                     break;
                case GBIVersion::f3dex:
-                    index = C0(0, 8);
-                    offset = C0(8, 8) * 8;
+                    uint32_t subcommand = (w0 >> 16) & 0xFF;
+                    offset = w1;
 
                     /* 
                      * Only generate lights on the second gsSPLight.
@@ -384,10 +384,9 @@ std::optional<std::shared_ptr<IParsedData>> DListFactory::parse(std::vector<uint
 	                 * gsSPLight(&name.l[0],1)
 	                 * gsSPLight(&name.a,2) <-- This ptr is used to generate the lights
                     */
-                    if (index == GBI(G_MV_L1)) {
+                    if (subcommand == GBI(G_MV_L1)) {
                         light = true;
                     }
-                    break;
                 default: {
                     index = C0(0, 8);
                     offset = C0(8, 8) * 8;

--- a/src/factories/DisplayListFactory.cpp
+++ b/src/factories/DisplayListFactory.cpp
@@ -385,9 +385,9 @@ std::optional<std::shared_ptr<IParsedData>> DListFactory::parse(std::vector<uint
                      * Only generate lights on the second gsSPLight.
                      * gsSPSetLights1(name) outputs three macros:
                      * 
-	             * gsSPNumLights(NUMLIGHTS_1)
-	             * gsSPLight(&name.l[0], G_MV_L0)
-	             * gsSPLight(&name.a, G_MV_L1) <-- This ptr is used to generate the lights
+	                 * gsSPNumLights(NUMLIGHTS_1)
+	                 * gsSPLight(&name.l[0], G_MV_L0)
+	                 * gsSPLight(&name.a, G_MV_L1) <-- This ptr is used to generate the lights
                     */
                     if (subcommand == GBI(G_MV_L1)) {
                         light = true;

--- a/src/factories/DisplayListFactory.cpp
+++ b/src/factories/DisplayListFactory.cpp
@@ -367,8 +367,8 @@ std::optional<std::shared_ptr<IParsedData>> DListFactory::parse(std::vector<uint
                 case GBIVersion::f3d:
                     index = C0(16, 8);
 
-                    if(index < GBI(G_MV_L0)) {
-                        continue;
+                    if(index == GBI(G_MV_L0) || index == GBI(G_MV_L1)) {
+                        light = true;
                     }
 
                     break;
@@ -391,8 +391,8 @@ std::optional<std::shared_ptr<IParsedData>> DListFactory::parse(std::vector<uint
                     index = C0(0, 8);
                     offset = C0(8, 8) * 8;
 
-                    if(index != GBI(G_MV_LIGHT)) {
-                        continue;
+                    if(index == GBI(G_MV_LIGHT)) {
+                        light = true;
                     }
                 }
             }

--- a/src/factories/DisplayListFactory.cpp
+++ b/src/factories/DisplayListFactory.cpp
@@ -358,8 +358,8 @@ std::optional<std::shared_ptr<IParsedData>> DListFactory::parse(std::vector<uint
             }
         }
 
-	// This opcode is generally used as part of multiple macros such as gsSPSetLights1.
-	// We need to process gsSPLight which is a subcommand inside G_MOVEMEM (0x03).
+	    // This opcode is generally used as part of multiple macros such as gsSPSetLights1.
+	    // We need to process gsSPLight which is a subcommand inside G_MOVEMEM (0x03).
         if(opcode == GBI(G_MOVEMEM)) {
 	    // 0x03860000 or 0x03880000 subcommand will contain 0x86/0x88 for G_MV_L0 and G_MV_L1. Other subcommands also exist.
 	    uint8_t subcommand = (w0 >> 16) & 0xFF;
@@ -376,8 +376,8 @@ std::optional<std::shared_ptr<IParsedData>> DListFactory::parse(std::vector<uint
                     }
 
                     break;
-	       // If needing light generation on G_MV_L0 then we'll need to walk the DL ptr forward/backward to check for 0xBC
-	       // Otherwise mk64 will break.
+	           // If needing light generation on G_MV_L0 then we'll need to walk the DL ptr forward/backward to check for 0xBC
+	           // Otherwise mk64 will break.
                case GBIVersion::f3dex:
                     offset = w1;
 


### PR DESCRIPTION
I documented a bit better what's going on here. This section was not really coded properly and it may be working only by fluke. Continue statement cannot be used in this function unless you want gfxdis itself to skip that gfx command. This will result in differing displaylist output.

This PR fixes f3dex games and attempts to fix the others. However, the others are untested. Other games will need to contribute their own fixes but I have hinted at a good way to do so. `C0` macro hides what's going on here. We should show our work when shifting here so that it's easier to debug and leave a comment showing the input and expected value of the variable.

`G_MV_LIGHT` is not a valid value according to:
https://hack64.net/wiki/doku.php?id=super_mario_64:fast3d_display_list_commands#g_movemem
But it is the gbi.h for `F3DEX_GBI_2` so I guess that's why it's not in there. But it was used in a default instead of f3dex2. I suspect the code isn't doing what the programmer thought it was doing.

Thus, I've replaced default with F3DEX2. The default behaviour is to not generate a light unless the code recognizes a light since `MOVEMEM` does more than just lights.