### PR TITLE
Add Include Factory

### DIFF
--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -1,13 +1,16 @@
 #include "Companion.h"
 
-#include "storm/SWrapper.h"
 #include "utils/Decompressor.h"
+#include "utils/TorchUtils.h"
+#include "storm/SWrapper.h"
+#include "spdlog/spdlog.h"
+#include "hj/sha1.h"
 
-#include "factories/sm64/AnimationFactory.h"
-#include "factories/sm64/DialogFactory.h"
-#include "factories/sm64/DictionaryFactory.h"
-#include "factories/sm64/TextFactory.h"
-#include "factories/sm64/GeoLayoutFactory.h"
+#include <regex>
+#include <fstream>
+#include <iostream>
+#include <filesystem>
+
 #include "factories/BankFactory.h"
 #include "factories/AudioHeaderFactory.h"
 #include "factories/SampleFactory.h"
@@ -15,23 +18,26 @@
 #include "factories/VtxFactory.h"
 #include "factories/MtxFactory.h"
 #include "factories/FloatFactory.h"
+#include "factories/IncludeFactory.h"
 #include "factories/TextureFactory.h"
 #include "factories/DisplayListFactory.h"
 #include "factories/DisplayListOverrides.h"
 #include "factories/BlobFactory.h"
 #include "factories/LightsFactory.h"
 #include "factories/Vec3fFactory.h"
+
+#include "factories/sm64/AnimationFactory.h"
+#include "factories/sm64/DialogFactory.h"
+#include "factories/sm64/DictionaryFactory.h"
+#include "factories/sm64/TextFactory.h"
+#include "factories/sm64/GeoLayoutFactory.h"
+
 #include "factories/mk64/CourseVtx.h"
 #include "factories/mk64/Waypoints.h"
 #include "factories/mk64/TrackSections.h"
 #include "factories/mk64/SpawnData.h"
 #include "factories/mk64/DrivingBehaviour.h"
-#include "spdlog/spdlog.h"
-#include "hj/sha1.h"
 
-#include <fstream>
-#include <iostream>
-#include <filesystem>
 #include "factories/sf64/ColPolyFactory.h"
 #include "factories/sf64/MessageFactory.h"
 #include "factories/sf64/MessageLookupFactory.h"
@@ -42,8 +48,6 @@
 #include "factories/sf64/EnvSettingsFactory.h"
 #include "factories/sf64/ObjInitFactory.h"
 #include "factories/sf64/TriangleFactory.h"
-#include <regex>
-#include "utils/TorchUtils.h"
 
 using namespace std::chrono;
 namespace fs = std::filesystem;
@@ -64,6 +68,7 @@ void Companion::Init(const ExportType type) {
     this->RegisterFactory("VTX", std::make_shared<VtxFactory>());
     this->RegisterFactory("MTX", std::make_shared<MtxFactory>());
     this->RegisterFactory("F32", std::make_shared<FloatFactory>());
+    this->RegisterFactory("INC", std::make_shared<IncludeFactory>());
     this->RegisterFactory("LIGHTS", std::make_shared<LightsFactory>());
     this->RegisterFactory("GFX", std::make_shared<DListFactory>());
     this->RegisterFactory("AUDIO:HEADER", std::make_shared<AudioHeaderFactory>());

--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -171,7 +171,7 @@ void Companion::ExtractNode(YAML::Node& node, std::string& name, SWrapper* binar
 
     auto factory = this->GetFactory(type);
     if(!factory.has_value()){
-        SPDLOG_ERROR("No factory found for {}", name);
+        throw std::runtime_error("No factory by the name '"+type+"' found for '"+name+"'");
         return;
     }
 

--- a/src/factories/IncludeFactory.cpp
+++ b/src/factories/IncludeFactory.cpp
@@ -22,10 +22,8 @@ ExportResult IncludeHeaderExporter::Export(std::ostream &write, std::shared_ptr<
 
 ExportResult IncludeCodeExporter::Export(std::ostream &write, std::shared_ptr<IParsedData> raw, std::string& entryName, YAML::Node &node, std::string* replacement ) {
     const auto symbol = GetSafeNode(node, "symbol", entryName);
-    auto offset = GetSafeNode<uint32_t>(node, "offset");
-    auto sym = GetSafeNode<size_t>(node, "symbol");
-    auto file = GetSafeNode<size_t>(node, "file_path");
-    auto ctype = GetSafeNode<size_t>(node, "ctype");
+    const auto file = GetSafeNode<size_t>(node, "file_path");
+    const auto ctype = GetSafeNode<size_t>(node, "ctype");
 
     write << ctype << " " << symbol << "[] = {\n";
 

--- a/src/factories/IncludeFactory.cpp
+++ b/src/factories/IncludeFactory.cpp
@@ -9,7 +9,7 @@
 
 ExportResult IncludeHeaderExporter::Export(std::ostream &write, std::shared_ptr<IParsedData> raw, std::string& entryName, YAML::Node &node, std::string* replacement) {
     const auto symbol = GetSafeNode(node, "symbol", entryName);
-    auto ctype = GetSafeNode<size_t>(node, "ctype");
+    auto ctype = GetSafeNode<std::string>(node, "ctype");
 
     if(Companion::Instance->IsOTRMode()){
         write << "static const char " << symbol << "[] = \"__OTR__" << (*replacement) << "\";\n\n";
@@ -22,9 +22,9 @@ ExportResult IncludeHeaderExporter::Export(std::ostream &write, std::shared_ptr<
 
 ExportResult IncludeCodeExporter::Export(std::ostream &write, std::shared_ptr<IParsedData> raw, std::string& entryName, YAML::Node &node, std::string* replacement ) {
     const auto symbol = GetSafeNode(node, "symbol", entryName);
-    const auto file = GetSafeNode<size_t>(node, "file_path");
-    const auto ctype = GetSafeNode<size_t>(node, "ctype");
-
+    const auto file = GetSafeNode<std::string>(node, "file_path");
+    const auto ctype = GetSafeNode<std::string>(node, "ctype");
+        SPDLOG_INFO("writing INC");
     write << ctype << " " << symbol << "[] = {\n";
 
     write << "#include '" << file << "'";
@@ -41,7 +41,8 @@ ExportResult IncludeBinaryExporter::Export(std::ostream &write, std::shared_ptr<
 
 std::optional<std::shared_ptr<IParsedData>> IncludeFactory::parse(std::vector<uint8_t>& buffer, YAML::Node& node) {
 
-    const uint32_t blank = 0;
+    SPDLOG_INFO("parsing INC");
+    const uint32_t blank = 1;
 
     return std::make_shared<IncludeData>(blank);
 }

--- a/src/factories/IncludeFactory.cpp
+++ b/src/factories/IncludeFactory.cpp
@@ -27,9 +27,9 @@ ExportResult IncludeCodeExporter::Export(std::ostream &write, std::shared_ptr<IP
         SPDLOG_INFO("writing INC");
     write << ctype << " " << symbol << "[] = {\n";
 
-    write << "#include '" << file << "'";
+    write << fourSpaceTab << "#include '" << file << "'\n";
 
-    write << "};\n";
+    write << "};\n\n";
 
     return std::nullopt;
 }

--- a/src/factories/IncludeFactory.cpp
+++ b/src/factories/IncludeFactory.cpp
@@ -1,0 +1,49 @@
+#include "IncludeFactory.h"
+#include "spdlog/spdlog.h"
+
+#include "Companion.h"
+#include "utils/Decompressor.h"
+
+#define NUM(x) std::dec << std::setfill(' ') << std::setw(6) << x
+#define COL(c) std::dec << std::setfill(' ') << std::setw(3) << c
+
+ExportResult IncludeHeaderExporter::Export(std::ostream &write, std::shared_ptr<IParsedData> raw, std::string& entryName, YAML::Node &node, std::string* replacement) {
+    const auto symbol = GetSafeNode(node, "symbol", entryName);
+    auto ctype = GetSafeNode<size_t>(node, "ctype");
+
+    if(Companion::Instance->IsOTRMode()){
+        write << "static const char " << symbol << "[] = \"__OTR__" << (*replacement) << "\";\n\n";
+        return std::nullopt;
+    }
+
+    write << "extern " << ctype << " " << symbol << "[];\n";
+    return std::nullopt;
+}
+
+ExportResult IncludeCodeExporter::Export(std::ostream &write, std::shared_ptr<IParsedData> raw, std::string& entryName, YAML::Node &node, std::string* replacement ) {
+    const auto symbol = GetSafeNode(node, "symbol", entryName);
+    auto offset = GetSafeNode<uint32_t>(node, "offset");
+    auto sym = GetSafeNode<size_t>(node, "symbol");
+    auto file = GetSafeNode<size_t>(node, "file_path");
+    auto ctype = GetSafeNode<size_t>(node, "ctype");
+
+    write << ctype << " " << symbol << "[] = {\n";
+
+    write << "#include '" << file << "'";
+
+    write << "};\n";
+
+    return std::nullopt;
+}
+
+ExportResult IncludeBinaryExporter::Export(std::ostream &write, std::shared_ptr<IParsedData> raw, std::string& entryName, YAML::Node &node, std::string* replacement ) {
+    throw std::runtime_error("Include factory should not be used for otr/o2r mode.");
+    return std::nullopt;
+}
+
+std::optional<std::shared_ptr<IParsedData>> IncludeFactory::parse(std::vector<uint8_t>& buffer, YAML::Node& node) {
+
+    const uint32_t blank = 0;
+
+    return std::make_shared<IncludeData>(blank);
+}

--- a/src/factories/IncludeFactory.h
+++ b/src/factories/IncludeFactory.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "BaseFactory.h"
+
+class IncludeData : public IParsedData {
+public:
+    uint32_t blanks;
+
+    explicit IncludeData(uint32_t blank) : blanks(blank) {}
+};
+
+class IncludeHeaderExporter : public BaseExporter {
+    ExportResult Export(std::ostream& write, std::shared_ptr<IParsedData> data, std::string& entryName, YAML::Node& node, std::string* replacement) override;
+};
+
+class IncludeBinaryExporter : public BaseExporter {
+    ExportResult Export(std::ostream& write, std::shared_ptr<IParsedData> data, std::string& entryName, YAML::Node& node, std::string* replacement) override;
+};
+
+class IncludeCodeExporter : public BaseExporter {
+    ExportResult Export(std::ostream& write, std::shared_ptr<IParsedData> data, std::string& entryName, YAML::Node& node, std::string* replacement) override;
+};
+
+class IncludeFactory : public BaseFactory {
+public:
+    std::optional<std::shared_ptr<IParsedData>> parse(std::vector<uint8_t>& buffer, YAML::Node& data) override;
+    inline std::unordered_map<ExportType, std::shared_ptr<BaseExporter>> GetExporters() override {
+        return {
+            REGISTER(Code, IncludeCodeExporter)
+            REGISTER(Header, IncludeHeaderExporter)
+            REGISTER(Binary, IncludeBinaryExporter)
+        };
+    }
+    uint32_t GetAlignment() override {
+        return 8;
+    };
+};

--- a/src/factories/TextureFactory.cpp
+++ b/src/factories/TextureFactory.cpp
@@ -174,8 +174,10 @@ ExportResult TextureCodeExporter::Export(std::ostream &write, std::shared_ptr<IP
 
         const auto sz = data.size();
         if (Companion::Instance->IsDebug()) {
-            write << "// size: 0x" << std::hex << std::uppercase << sz << "\n";
+            write << "// size: 0x" << std::hex << std::uppercase << sz;
         }
+
+        write << "\n";
     }
     return offset + data.size();
 }


### PR DESCRIPTION
Adds the ability to generate:
```c
MySym sym[] = {
    #include "my_file/file.inc.c"
};
```
Needed for metadata tables that are in yaml generated files.

```yml
sym:
    symbol: sym
    type: inc
    file_path: path_to_file.inc.c
    ctype: Vtx   # C data type here
    offset: 0x0 # Only required so Torch can order the assets. The factory does not use it.
```

Also, fixed TextureFactory `\n` spacing after `};`