### PR TITLE
Basic External File Implementation

### DIFF
--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -415,6 +415,8 @@ void Companion::ParseCurrentFileConfig(YAML::Node node) {
                 auto externalFileName = externalFile.as<std::string>();
                 if (std::filesystem::relative(externalFileName, this->gAssetPath).string().starts_with("../")) {
                     throw std::runtime_error("External File " + externalFileName + " Not In Asset Directory " + this->gAssetPath);
+                } else if (std::filesystem::relative(externalFileName, this->gAssetPath).string() == "") {
+                    throw std::runtime_error("External File " + externalFileName + " Not In Asset Directory " + this->gAssetPath);
                 }
                 auto localCurrentDirectory = std::filesystem::relative(externalFileName, this->gAssetPath).replace_extension("");
 

--- a/src/Companion.h
+++ b/src/Companion.h
@@ -150,6 +150,7 @@ private:
     std::optional<VRAMEntry> gCurrentVram;
     CompressionType gCurrentCompressionType = CompressionType::None;
     std::vector<Table> gTables;
+    std::vector<std::string> gCurrentExternalFiles;
     std::variant<std::vector<std::string>, std::string> gWriteOrder;
     std::unordered_map<std::string, std::shared_ptr<BaseFactory>> gFactories;
     std::unordered_map<std::string, std::string> gModdedAssetPaths;

--- a/src/Companion.h
+++ b/src/Companion.h
@@ -131,6 +131,7 @@ private:
     YAML::Node gModdingConfig;
     fs::path gCurrentDirectory;
     std::string gCurrentHash;
+    std::string gAssetPath;
     std::vector<uint8_t> gRomData;
     std::filesystem::path gRomPath;
     bool gNodeForceProcessing = false;


### PR DESCRIPTION
This adds checking to the GetNodeByAddr to check against listed external files if it cannot find it in the current file. This requires adding dummy pass through a file adding asset nodes to the gAddrMap if a file hasnt been passed through. 