### PR TITLE
Add `individual_data_incs` option

### DIFF
--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -717,6 +717,7 @@ void Companion::Process() {
         this->gCurrentVram = std::nullopt;
         this->gCurrentSegmentNumber = 0;
         this->gCurrentCompressionType = CompressionType::None;
+        this->gCurrentFileOffset = 0;
         this->gTables.clear();
         this->gCurrentExternalFiles.clear();
         GFXDOverride::ClearVtx();

--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -354,7 +354,7 @@ void Companion::ParseCurrentFileConfig(YAML::Node node) {
 
     this->gEnablePadGen = GetSafeNode<bool>(node, "autopads", true);
     this->gNodeForceProcessing = GetSafeNode<bool>(node, "force", false);
-    this->gSingleCodeFile = !GetSafeNode<bool>(node, "individual_data_incs", false);
+    this->gIndividualIncludes = GetSafeNode<bool>(node, "individual_data_incs", false);
 }
 
 void Companion::ParseHash() {
@@ -953,7 +953,7 @@ void Companion::Process() {
                     stream << "// 0x" << std::hex << std::uppercase << ASSET_PTR(result.endptr.value()) << "\n\n";
                 }
 
-                if(hasSize && i < entries.size() - 1 && this->gConfig.exporterType == ExportType::Code && this->gSingleCodeFile){
+                if(hasSize && i < entries.size() - 1 && this->gConfig.exporterType == ExportType::Code && !this->gIndividualIncludes){
                     int32_t startptr = ASSET_PTR(result.endptr.value());
                     int32_t end = ASSET_PTR(entries[i + 1].addr);
 
@@ -986,7 +986,7 @@ void Companion::Process() {
                     }
                 }
 
-                if (this->gConfig.exporterType == ExportType::Code && !this->gSingleCodeFile) {
+                if (this->gConfig.exporterType == ExportType::Code && this->gIndividualIncludes) {
                     fs::path outinc = fs::path(this->gConfig.outputPath) / this->gCurrentDirectory.parent_path() / (result.name + ".inc.c");
     
                     if(!exists(outinc.parent_path())){
@@ -1007,7 +1007,7 @@ void Companion::Process() {
 
             this->gWriteMap.clear();
 
-            if (this->gConfig.exporterType != ExportType::Code || this->gSingleCodeFile) {
+            if (this->gConfig.exporterType != ExportType::Code || !this->gIndividualIncludes) {
                 std::string buffer = stream.str();
 
                 if(buffer.empty()) {

--- a/src/Companion.h
+++ b/src/Companion.h
@@ -118,7 +118,7 @@ public:
     GBIMinorVersion GetGBIMinorVersion() const { return  this->gConfig.gbi.subversion; }
     std::unordered_map<std::string, std::vector<YAML::Node>> GetCourseMetadata() { return this->gCourseMetadata; }
     std::optional<std::string> GetEnumFromValue(const std::string& key, int id);
-    bool IsSingleCodeFile() const { return this->gIndividualIncludes; }
+    bool IsUsingIndividualIncludes() const { return this->gIndividualIncludes; }
 
     std::optional<ParseResultData> GetParseDataByAddr(uint32_t addr);
     std::optional<ParseResultData> GetParseDataBySymbol(const std::string& symbol);

--- a/src/Companion.h
+++ b/src/Companion.h
@@ -118,7 +118,7 @@ public:
     GBIMinorVersion GetGBIMinorVersion() const { return  this->gConfig.gbi.subversion; }
     std::unordered_map<std::string, std::vector<YAML::Node>> GetCourseMetadata() { return this->gCourseMetadata; }
     std::optional<std::string> GetEnumFromValue(const std::string& key, int id);
-    bool IsSingleCodeFile() const { return this->gSingleCodeFile; }
+    bool IsSingleCodeFile() const { return this->gIndividualIncludes; }
 
     std::optional<ParseResultData> GetParseDataByAddr(uint32_t addr);
     std::optional<ParseResultData> GetParseDataBySymbol(const std::string& symbol);
@@ -154,7 +154,7 @@ private:
     std::vector<uint8_t> gRomData;
     std::filesystem::path gRomPath;
     bool gNodeForceProcessing = false;
-    bool gSingleCodeFile = true;
+    bool gIndividualIncludes = false;
     YAML::Node gHashNode;
     std::shared_ptr<N64::Cartridge> gCartridge;
     std::unordered_map<std::string, std::vector<YAML::Node>> gCourseMetadata;

--- a/src/Companion.h
+++ b/src/Companion.h
@@ -53,6 +53,7 @@ struct VRAMEntry {
 };
 
 struct WriteEntry {
+    std::string name;
     uint32_t addr;
     uint32_t alignment;
     std::string buffer;
@@ -117,6 +118,7 @@ public:
     GBIMinorVersion GetGBIMinorVersion() const { return  this->gConfig.gbi.subversion; }
     std::unordered_map<std::string, std::vector<YAML::Node>> GetCourseMetadata() { return this->gCourseMetadata; }
     std::optional<std::string> GetEnumFromValue(const std::string& key, int id);
+    bool IsSingleCodeFile() const { return this->gSingleCodeFile; }
 
     std::optional<ParseResultData> GetParseDataByAddr(uint32_t addr);
     std::optional<ParseResultData> GetParseDataBySymbol(const std::string& symbol);
@@ -152,6 +154,7 @@ private:
     std::vector<uint8_t> gRomData;
     std::filesystem::path gRomPath;
     bool gNodeForceProcessing = false;
+    bool gSingleCodeFile = true;
     YAML::Node gHashNode;
     std::shared_ptr<N64::Cartridge> gCartridge;
     std::unordered_map<std::string, std::vector<YAML::Node>> gCourseMetadata;

--- a/src/factories/TextureFactory.cpp
+++ b/src/factories/TextureFactory.cpp
@@ -158,7 +158,7 @@ ExportResult TextureCodeExporter::Export(std::ostream &write, std::shared_ptr<IP
     }
     imgstream << std::endl;
 
-    if (Companion::Instance->IsSingleCodeFile()){
+    if (!Companion::Instance->IsUsingIndividualIncludes()){
         std::ofstream file(dpath + ".inc.c", std::ios::binary);
         file << imgstream.str();
         file.close();
@@ -178,7 +178,7 @@ ExportResult TextureCodeExporter::Export(std::ostream &write, std::shared_ptr<IP
         }
 
         write << tab << "{\n";
-        if (Companion::Instance->IsSingleCodeFile()){
+        if (!Companion::Instance->IsUsingIndividualIncludes()){
             write << tab << tab << "#include \"" << Companion::Instance->GetOutputPath() + "/" << *replacement << ".inc.c\"\n";
         } else {
             write << imgstream.str();
@@ -194,7 +194,7 @@ ExportResult TextureCodeExporter::Export(std::ostream &write, std::shared_ptr<IP
     } else {
         write << GetSafeNode<std::string>(node, "ctype", "u8") << " " << symbol  << "[] = {\n";
 
-        if (Companion::Instance->IsSingleCodeFile()){
+        if (!Companion::Instance->IsUsingIndividualIncludes()){
             write << tab << "#include \"" << Companion::Instance->GetOutputPath() + "/" << *replacement << ".inc.c\"\n";
         } else {
             write << imgstream.str();


### PR DESCRIPTION
This adds the config option `individual_data_incs` that writes every defined asset into their own `.inc.c` files separately.
Inspired by **splat**'s way of generating gfx and vtx segments, this makes it possible to include them in the source files, which is almost impractical to do, for instance, a `Gfx` data containing `gsSPViewport` and its associated `Vp` data, or a variable somewhere between and is required by the game engine.

Untested for modding import mode and might break when enabled, as I haven't tried to do as of this. I suspect it's unfinished, so I won't touch this part yet.

For all types, it outputs definitions + data in their own files in an example shown below:
```c
// 0x80075880
u16 theater_floor_pal[] = {
0xe5d7, 0x9bc9, 0x7285, 0xbccf, 0xee9f, 0xdd93, 0xa40d, 0x9345, 
0x6203, 0xc515, 0xe61b, 0xac4f, 0xcd11, 0x8309, 0xb4d5, 0xd555, 
};
// size: 0x20
// 0x800758A0
```