### PR TITLE
add index size override option for tables

### DIFF
--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -314,7 +314,8 @@ void Companion::ParseCurrentFileConfig(YAML::Node node) {
             auto end = gCurrentSegmentNumber ? gCurrentSegmentNumber << 24 | range[1] : range[1];
             auto mode = GetSafeNode<std::string>(table->second, "mode", "APPEND");
             TableMode tMode = mode == "REFERENCE" ? TableMode::Reference : TableMode::Append;
-            this->gTables.push_back({name, start, end, tMode});
+            auto index_size = GetSafeNode<int32_t>(table->second, "index_size", -1);
+            this->gTables.push_back({name, start, end, tMode, index_size});
         }
     }
 

--- a/src/Companion.h
+++ b/src/Companion.h
@@ -45,6 +45,7 @@ struct Table {
     uint32_t start;
     uint32_t end;
     TableMode mode;
+    int32_t index_size;
 };
 
 struct VRAMEntry {

--- a/src/factories/LightsFactory.cpp
+++ b/src/factories/LightsFactory.cpp
@@ -16,7 +16,7 @@ ExportResult LightsHeaderExporter::Export(std::ostream &write, std::shared_ptr<I
     const auto searchTable = Companion::Instance->SearchTable(offset);
 
     if(searchTable.has_value()){
-        const auto [name, start, end, mode] = searchTable.value();
+        const auto [name, start, end, mode, index_size] = searchTable.value();
 
         if(start != offset){
             return std::nullopt;
@@ -36,7 +36,7 @@ ExportResult LightsCodeExporter::Export(std::ostream &write, std::shared_ptr<IPa
     const auto searchTable = Companion::Instance->SearchTable(offset);
 
     if(searchTable.has_value()){
-        const auto [name, start, end, mode] = searchTable.value();
+        const auto [name, start, end, mode, index_size] = searchTable.value();
 
 
         if(start == offset){

--- a/src/factories/TextureFactory.cpp
+++ b/src/factories/TextureFactory.cpp
@@ -93,7 +93,8 @@ ExportResult TextureHeaderExporter::Export(std::ostream &write, std::shared_ptr<
     const auto searchTable = Companion::Instance->SearchTable(offset);
 
     if(searchTable.has_value()){
-        const auto [name, start, end, mode] = searchTable.value();
+        const auto [name, start, end, mode, index_size] = searchTable.value();
+        unsigned int isize = index_size > -1 ? index_size : data.size() / byteSize;
 
         if(isOTR){
             write << "static const ALIGN_ASSET(2) char " << symbol << "[] = \"__OTR__" << (*replacement) << "\";\n\n";
@@ -109,7 +110,7 @@ ExportResult TextureHeaderExporter::Export(std::ostream &write, std::shared_ptr<
                 tableEntries.clear();
             }
         } else {
-            write << "extern " << GetSafeNode<std::string>(node, "ctype", "u8") << " " << name << "[][" << (data.size() / byteSize) << "];\n";
+            write << "extern " << GetSafeNode<std::string>(node, "ctype", "u8") << " " << name << "[][" << isize << "];\n";
         }
     } else {
         if(isOTR){
@@ -140,6 +141,7 @@ ExportResult TextureCodeExporter::Export(std::ostream &write, std::shared_ptr<IP
     std::ofstream file(dpath + ".inc.c", std::ios::binary);
 
     size_t byteSize = std::max(1, (int) (texture->mFormat.depth / 8));
+    size_t isize = texture->mBuffer.size() / byteSize;
 
     SPDLOG_INFO("Byte Size: {}", byteSize);
 
@@ -163,14 +165,18 @@ ExportResult TextureCodeExporter::Export(std::ostream &write, std::shared_ptr<IP
     const auto searchTable = Companion::Instance->SearchTable(offset);
 
     if(searchTable.has_value()){
-        const auto [name, start, end, mode] = searchTable.value();
+        const auto [name, start, end, mode, index_size] = searchTable.value();
 
         if(mode != TableMode::Append){
             throw std::runtime_error("Reference mode is not supported for now");
         }
 
+        if (index_size > -1) {
+            isize = index_size;
+        }
+
         if(start == offset){
-            write << GetSafeNode<std::string>(node, "ctype", "u8") << " " << name << "[][" << (texture->mBuffer.size() / byteSize) << "] = {\n";
+            write << GetSafeNode<std::string>(node, "ctype", "u8") << " " << name << "[][" << isize << "] = {\n";
         }
 
         write << tab << "{\n";
@@ -180,7 +186,7 @@ ExportResult TextureCodeExporter::Export(std::ostream &write, std::shared_ptr<IP
         if(end == offset){
             write << "};\n";
             if (Companion::Instance->IsDebug()) {
-                write << "// size: 0x" << std::hex << std::uppercase << ASSET_PTR((end - start) + data.size()) << "\n";
+                write << "// size: 0x" << std::hex << std::uppercase << ASSET_PTR((end - start) + isize * byteSize) << "\n";
             }
         }
     } else {
@@ -196,7 +202,7 @@ ExportResult TextureCodeExporter::Export(std::ostream &write, std::shared_ptr<IP
 
         write << "\n";
     }
-    return offset + data.size();
+    return offset + isize * byteSize;
 }
 
 ExportResult TextureBinaryExporter::Export(std::ostream &write, std::shared_ptr<IParsedData> raw, std::string& entryName, YAML::Node &node, std::string* replacement) {

--- a/src/factories/VtxFactory.cpp
+++ b/src/factories/VtxFactory.cpp
@@ -20,7 +20,8 @@ ExportResult VtxHeaderExporter::Export(std::ostream &write, std::shared_ptr<IPar
     const auto searchTable = Companion::Instance->SearchTable(offset);
 
     if(searchTable.has_value()){
-        const auto [name, start, end, mode] = searchTable.value();
+        const auto [name, start, end, mode, index_size] = searchTable.value();
+        // We will ignore the overriden index_size for now...
 
         if(start != offset){
             return std::nullopt;
@@ -41,7 +42,7 @@ ExportResult VtxCodeExporter::Export(std::ostream &write, std::shared_ptr<IParse
     const auto searchTable = Companion::Instance->SearchTable(offset);
 
     if(searchTable.has_value()){
-        const auto [name, start, end, mode] = searchTable.value();
+        const auto [name, start, end, mode, index_size] = searchTable.value();
 
 
         if(start == offset){

--- a/src/factories/mk64/ItemCurve.cpp
+++ b/src/factories/mk64/ItemCurve.cpp
@@ -28,7 +28,8 @@ ExportResult MK64::ItemCurveCodeExporter::Export(std::ostream &write, std::share
     const auto searchTable = Companion::Instance->SearchTable(offset);
 
     if(searchTable.has_value()){
-        const auto [name, start, end, mode] = searchTable.value();
+        const auto [name, start, end, mode, index_size] = searchTable.value();
+        // We will ignore the overriden index_size for now...
 
         if(start == offset){
             write << GetSafeNode<std::string>(node, "ctype", "u8") << " " << name << "[][" << items.size() << "] = {\n";


### PR DESCRIPTION
The problem is that you can't insert a pad onto a table. The solution was to manually forcing it to extend the index *(inner?)* size to absorb the pad to its previous data.