### PR TITLE
Asset Array Factory

### DIFF
--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -27,6 +27,7 @@
 #include "factories/LightsFactory.h"
 #include "factories/Vec3fFactory.h"
 #include "factories/Vec3sFactory.h"
+#include "factories/AssetArrayFactory.h"
 
 #include "factories/sm64/AnimationFactory.h"
 #include "factories/sm64/CollisionFactory.h"
@@ -88,6 +89,7 @@ void Companion::Init(const ExportType type) {
     this->RegisterFactory("VEC3F", std::make_shared<Vec3fFactory>());
     this->RegisterFactory("VEC3S", std::make_shared<Vec3sFactory>());
     this->RegisterFactory("ARRAY", std::make_shared<GenericArrayFactory>());
+    this->RegisterFactory("ASSET_ARRAY", std::make_shared<AssetArrayFactory>());
 
     // SM64 specific
     this->RegisterFactory("SM64:DIALOG", std::make_shared<SM64::DialogFactory>());

--- a/src/factories/AssetArrayFactory.cpp
+++ b/src/factories/AssetArrayFactory.cpp
@@ -1,0 +1,98 @@
+#include "AssetArrayFactory.h"
+#include "spdlog/spdlog.h"
+
+#include "Companion.h"
+#include "utils/Decompressor.h"
+#include "utils/TorchUtils.h"
+#include <regex>
+
+#define FORMAT_HEX(ptr) (ptr)
+
+ExportResult AssetArrayHeaderExporter::Export(std::ostream &write, std::shared_ptr<IParsedData> raw, std::string& entryName, YAML::Node &node, std::string* replacement) {
+    const auto symbol = GetSafeNode(node, "symbol", entryName);
+    auto data = std::static_pointer_cast<AssetArrayData>(raw);
+
+    if(Companion::Instance->IsOTRMode()){
+        write << "static const char " << symbol << "[] = \"__OTR__" << (*replacement) << "\";\n\n";
+        return std::nullopt;
+    }
+
+    write << "extern " << data->mType << "* " << symbol << "[];\n";
+    return std::nullopt;
+}
+
+ExportResult AssetArrayCodeExporter::Export(std::ostream &write, std::shared_ptr<IParsedData> raw, std::string& entryName, YAML::Node &node, std::string* replacement ) {
+    const auto symbol = GetSafeNode(node, "symbol", entryName);
+    const auto offset = GetSafeNode<uint32_t>(node, "offset");
+
+    auto data = std::static_pointer_cast<AssetArrayData>(raw);
+
+    write << "static " << data->mType << "* " << symbol << "[] = {\n";
+    for (auto ptr : data->mPtrs) {
+        write << fourSpaceTab;
+        auto dec = Companion::Instance->GetNodeByAddr(ptr);
+        if (dec.has_value()) {
+            auto node = std::get<1>(dec.value());
+            auto assetSymbol = GetSafeNode<std::string>(node, "symbol");
+            write << "&" << assetSymbol << ",\n";
+        } else {
+            write << FORMAT_HEX(ptr) << ",\n";
+        }
+    }
+    write << "};\n";
+
+    size_t size = (data->mPtrs.size()) * sizeof(uint32_t);
+
+    return offset + size;
+}
+
+ExportResult AssetArrayBinaryExporter::Export(std::ostream &write, std::shared_ptr<IParsedData> raw, std::string& entryName, YAML::Node &node, std::string* replacement ) {
+    auto writer = LUS::BinaryWriter();
+    auto data = std::static_pointer_cast<AssetArrayData>(raw);
+
+    WriteHeader(writer, LUS::ResourceType::AssetArray, 0);
+
+    writer.Write((uint32_t)data->mPtrs.size());
+    
+    for (auto ptr : data->mPtrs) {
+        if (ptr == 0) {
+            writer.Write((uint64_t)0);
+            continue;
+        }
+
+        auto dec = Companion::Instance->GetNodeByAddr(ptr);
+        if (dec.has_value()) {
+            uint64_t hash = CRC64(std::get<0>(dec.value()).c_str());
+            SPDLOG_INFO("Found Asset: 0x{:X} Hash: 0x{:X} Path: {}", ptr, hash, std::get<0>(dec.value()));
+            writer.Write(hash);
+        } else {
+            SPDLOG_WARN("Could not find Asset at 0x{:X}", ptr);
+        }
+    }
+
+    writer.Finish(write);
+    return std::nullopt;
+}
+
+std::optional<std::shared_ptr<IParsedData>> AssetArrayFactory::parse(std::vector<uint8_t>& buffer, YAML::Node& node) {
+    std::vector<uint32_t> ptrs;
+    auto assetType = GetSafeNode<std::string>(node, "assetType");
+    auto factoryType = GetSafeNode<std::string>(node, "factoryType");
+    const auto count = GetSafeNode<uint32_t>(node, "count");
+    auto [_, segment] = Decompressor::AutoDecode(node, buffer);
+    LUS::BinaryReader reader(segment.data, segment.size);
+    reader.SetEndianness(LUS::Endianness::Big);
+
+    for (uint32_t i = 0; i < count; ++i) {
+        auto ptr = reader.ReadUInt32();
+
+        YAML::Node assetNode;
+        assetNode["type"] = factoryType;
+        assetNode["offset"] = ptr;
+        Companion::Instance->AddAsset(assetNode);
+
+        ptrs.emplace_back(ptr);
+    }
+
+    return std::make_shared<AssetArrayData>(ptrs, assetType);
+}

--- a/src/factories/AssetArrayFactory.h
+++ b/src/factories/AssetArrayFactory.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "factories/BaseFactory.h"
+
+class AssetArrayData : public IParsedData {
+public:
+    std::vector<uint32_t> mPtrs;
+    std::string mType;
+
+    AssetArrayData(std::vector<uint32_t> ptrs, std::string type) : mPtrs(std::move(ptrs)), mType(type) {}
+};
+
+class AssetArrayHeaderExporter : public BaseExporter {
+    ExportResult Export(std::ostream& write, std::shared_ptr<IParsedData> data, std::string& entryName, YAML::Node& node, std::string* replacement) override;
+};
+
+class AssetArrayBinaryExporter : public BaseExporter {
+    ExportResult Export(std::ostream& write, std::shared_ptr<IParsedData> data, std::string& entryName, YAML::Node& node, std::string* replacement) override;
+};
+
+class AssetArrayCodeExporter : public BaseExporter {
+    ExportResult Export(std::ostream& write, std::shared_ptr<IParsedData> data, std::string& entryName, YAML::Node& node, std::string* replacement) override;
+};
+
+class AssetArrayFactory : public BaseFactory {
+public:
+    std::optional<std::shared_ptr<IParsedData>> parse(std::vector<uint8_t>& buffer, YAML::Node& data) override;
+    inline std::unordered_map<ExportType, std::shared_ptr<BaseExporter>> GetExporters() override {
+        return {
+            REGISTER(Code, AssetArrayCodeExporter)
+            REGISTER(Header, AssetArrayHeaderExporter)
+            REGISTER(Binary, AssetArrayBinaryExporter)
+        };
+    }
+};

--- a/src/factories/ResourceType.h
+++ b/src/factories/ResourceType.h
@@ -22,6 +22,7 @@ enum class ResourceType {
     Vec3f = 0x56433346,        // VC3F
     Vec3s = 0x56433353,        // VC3S
     GenericArray = 0x47415252, // GARR
+    AssetArray = 0x41415252,   // AARR
 
     // SM64
     Anim = 0x414E494D,         // ANIM


### PR DESCRIPTION
This is a light purpose factory for simple asset (only require offset and factory type) arrays with autogeneration. The alternative is to support all array factories but lose the autogeneration ability, which may be preferable so let me know. 

An example yaml for this factory is below

```yaml
ttm_seg7_painting_texture_maps_07012E88:
  type: ASSET_ARRAY
  assetType: PaintingData
  factoryType: SM64:PAINTING_MAP
  count: 2
  offset: 0x12E88
  symbol: ttm_seg7_painting_texture_maps_07012E88
```