### PR TITLE
Fix Movtex Code Output

### DIFF
--- a/src/factories/sm64/MovtexFactory.cpp
+++ b/src/factories/sm64/MovtexFactory.cpp
@@ -29,26 +29,26 @@ ExportResult SM64::MovtexCodeExporter::Export(std::ostream &write, std::shared_p
 
     if (movtex->mIsQuad) {
         auto numLists = movtex->mMovtexData.at(0);
-        write << "MOV_TEX_INIT_LOAD(" << numLists << "),\n";
+        write << fourSpaceTab << "MOV_TEX_INIT_LOAD(" << numLists << "),\n";
         additionalSize++; // MOV_TEX_INIT_LOAD has additional padding
         for (uint32_t i = 0; i < numLists; ++i) {
-            write << "MOV_TEX_ROT_SPEED(" << movtex->mMovtexData.at(i * 14 + 1) << "),\n";
-            write << "MOV_TEX_ROT_SCALE(" << movtex->mMovtexData.at(i * 14 + 2) << "),\n";
-            write << "MOV_TEX_4_BOX_TRIS(" << movtex->mMovtexData.at(i * 14 + 3) << ", " << movtex->mMovtexData.at(i * 14 + 4) << "),\n";
-            write << "MOV_TEX_4_BOX_TRIS(" << movtex->mMovtexData.at(i * 14 + 5) << ", " << movtex->mMovtexData.at(i * 14 + 6) << "),\n";
-            write << "MOV_TEX_4_BOX_TRIS(" << movtex->mMovtexData.at(i * 14 + 7) << ", " << movtex->mMovtexData.at(i * 14 + 8) << "),\n";
-            write << "MOV_TEX_4_BOX_TRIS(" << movtex->mMovtexData.at(i * 14 + 9) << ", " << movtex->mMovtexData.at(i * 14 + 10) << "),\n";
-            write << "MOV_TEX_ROT(" << movtex->mMovtexData.at(i * 14 + 11) << "),\n";
-            write << "MOV_TEX_ALPHA(" << movtex->mMovtexData.at(i * 14 + 12) << "),\n";
-            write << "MOV_TEX_DEFINE(" << movtex->mMovtexData.at(i * 14 + 13) << "),\n";
-            write << "MOV_TEX_END(),\n";
+            write << fourSpaceTab << "MOV_TEX_ROT_SPEED(" << movtex->mMovtexData.at(i * 14 + 1) << "),\n";
+            write << fourSpaceTab << "MOV_TEX_ROT_SCALE(" << movtex->mMovtexData.at(i * 14 + 2) << "),\n";
+            write << fourSpaceTab << "MOV_TEX_4_BOX_TRIS(" << movtex->mMovtexData.at(i * 14 + 3) << ", " << movtex->mMovtexData.at(i * 14 + 4) << "),\n";
+            write << fourSpaceTab << "MOV_TEX_4_BOX_TRIS(" << movtex->mMovtexData.at(i * 14 + 5) << ", " << movtex->mMovtexData.at(i * 14 + 6) << "),\n";
+            write << fourSpaceTab << "MOV_TEX_4_BOX_TRIS(" << movtex->mMovtexData.at(i * 14 + 7) << ", " << movtex->mMovtexData.at(i * 14 + 8) << "),\n";
+            write << fourSpaceTab << "MOV_TEX_4_BOX_TRIS(" << movtex->mMovtexData.at(i * 14 + 9) << ", " << movtex->mMovtexData.at(i * 14 + 10) << "),\n";
+            write << fourSpaceTab << "MOV_TEX_ROT(" << movtex->mMovtexData.at(i * 14 + 11) << "),\n";
+            write << fourSpaceTab << "MOV_TEX_ALPHA(" << movtex->mMovtexData.at(i * 14 + 12) << "),\n";
+            write << fourSpaceTab << "MOV_TEX_DEFINE(" << movtex->mMovtexData.at(i * 14 + 13) << "),\n";
+            write << fourSpaceTab << "MOV_TEX_END(),\n";
         }
     } else {
-        write << "MOV_TEX_SPEED(" << movtex->mMovtexData.at(0) << "),\n";
+        write << fourSpaceTab << "MOV_TEX_SPEED(" << movtex->mMovtexData.at(0) << "),\n";
         if (movtex->mHasColor) {
             for (uint32_t i = 0; i < movtex->mVertexCount; ++i) {
                 // There is also a MOV_TEX_LIGHT_TRIS macro, however this is identical in result to using MOV_TEX_ROT_TRIS and would require more params on the yaml
-                write << "MOV_TEX_ROT_TRIS(";
+                write << fourSpaceTab << "MOV_TEX_ROT_TRIS(";
                 write << movtex->mMovtexData.at(i * 8 + 0 + 1) << ", ";
                 write << movtex->mMovtexData.at(i * 8 + 1 + 1) << ", ";
                 write << movtex->mMovtexData.at(i * 8 + 2 + 1) << ", ";
@@ -60,18 +60,18 @@ ExportResult SM64::MovtexCodeExporter::Export(std::ostream &write, std::shared_p
             }
         } else {
             for (uint32_t i = 0; i < movtex->mVertexCount; ++i) {
-                write << "MOV_TEX_TRIS(";
-                write << movtex->mMovtexData.at(i * 8 + 0 + 1) << ", ";
-                write << movtex->mMovtexData.at(i * 8 + 1 + 1) << ", ";
-                write << movtex->mMovtexData.at(i * 8 + 2 + 1) << ", ";
-                write << movtex->mMovtexData.at(i * 8 + 3 + 1) << ", ";
-                write << movtex->mMovtexData.at(i * 8 + 4 + 1) << "),\n";
+                write << fourSpaceTab << "MOV_TEX_TRIS(";
+                write << movtex->mMovtexData.at(i * 5 + 0 + 1) << ", ";
+                write << movtex->mMovtexData.at(i * 5 + 1 + 1) << ", ";
+                write << movtex->mMovtexData.at(i * 5 + 2 + 1) << ", ";
+                write << movtex->mMovtexData.at(i * 5 + 3 + 1) << ", ";
+                write << movtex->mMovtexData.at(i * 5 + 4 + 1) << "),\n";
             }
         }
-        write << "MOV_TEX_END(),\n";
+        write << fourSpaceTab << "MOV_TEX_END(),\n";
     }
 
-    write << "\n};\n";
+    write << "};\n";
 
     size_t size = (movtex->mMovtexData.size() + additionalSize) * sizeof(int16_t);
 

--- a/src/factories/sm64/MovtexQuadFactory.cpp
+++ b/src/factories/sm64/MovtexQuadFactory.cpp
@@ -27,7 +27,7 @@ ExportResult SM64::MovtexQuadCodeExporter::Export(std::ostream &write, std::shar
     write << "const struct MovtexQuadCollection " << symbol << "[] = {\n";
 
     for (auto &quad: quadData->mMovtexQuads) {
-        write << "{" << quad.first << ", ";
+        write << fourSpaceTab << "{" << quad.first << ", ";
         if (quad.second == 0) {
             write << "NULL";
         } else {
@@ -44,7 +44,7 @@ ExportResult SM64::MovtexQuadCodeExporter::Export(std::ostream &write, std::shar
         write << "},\n";
     }
 
-    write << "\n};\n";
+    write << "};\n";
 
     if (Companion::Instance->IsDebug()) {
         write << "// MovtexQuad count: " << quadData->mMovtexQuads.size() << "\n";


### PR DESCRIPTION
MOV_TEX_TRIS has only 5 entries, while MOV_TEX_ROT_TRIS has 8, however the code output loop for MOV_TEX_TRIS was still assuming entry size of 8 (`mMovtexData.at(i * 8...)`), thus causing an index OOB error when trying to write them. This changes that to 5 for the normal number of entries.

Also adds tabspace formatting to the code output for Movtex and MovtexQuad.