### PR TITLE
Better lib 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,6 @@ add_dependencies(${PROJECT_NAME} N64Graphics)
 target_link_libraries(${PROJECT_NAME} PRIVATE N64Graphics)
 
 # Link StormLib
-
 if (BUILD_STORMLIB)
     set(STORM_BUILD_TESTS OFF)
     set(STORMLIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/StormLib)
@@ -221,16 +220,25 @@ FetchContent_Declare(
 )
 set(YAML_CPP_BUILD_TESTS OFF)
 FetchContent_MakeAvailable(yaml-cpp)
+
 target_link_libraries(${PROJECT_NAME} PRIVATE yaml-cpp)
+if(NOT USE_STANDALONE)
+	target_compile_definitions(yaml-cpp PRIVATE YAML_CPP_STATIC_DEFINE)
+endif()
 
-FetchContent_Declare(
-    spdlog
-    GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG 7e635fca68d014934b4af8a1cf874f63989352b7
-)
+if(USE_STANDALONE)
+	FetchContent_Declare(
+		spdlog
+		GIT_REPOSITORY https://github.com/gabime/spdlog.git
+		GIT_TAG 7e635fca68d014934b4af8a1cf874f63989352b7
+	)
 
-FetchContent_MakeAvailable(spdlog)
-target_link_libraries(${PROJECT_NAME} PRIVATE spdlog)
+	FetchContent_MakeAvailable(spdlog)
+	target_link_libraries(${PROJECT_NAME} PRIVATE spdlog)
+else()
+	find_package(spdlog REQUIRED)
+	target_link_libraries(${PROJECT_NAME} PUBLIC spdlog::spdlog)
+endif()
 
 if((CMAKE_SYSTEM_NAME MATCHES "Windows") AND ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
     include(../cmake/HandleCompilerRT.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     set(CMAKE_CXX_FLAGS_RELEASE "-O3")
     set(CMAKE_CXX_FLAGS "-Wno-narrowing")
 else()
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:16777216")
     if("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x64")
         target_compile_options(${PROJECT_NAME} PRIVATE
             $<$<CONFIG:Debug>:
@@ -110,7 +111,6 @@ else()
                 /${LINK_TYPE}
             >
             /bigobj
-            /STACK:16777216
             /permissive-;
             /MP;
             ${DEFAULT_CXX_DEBUG_INFORMATION_FORMAT};
@@ -128,7 +128,6 @@ else()
                 /Gy;
                 /${LINK_TYPE}
             >
-            /STACK:16777216
             /permissive-;
             /bigobj
             /MP;
@@ -149,7 +148,6 @@ else()
                 /FORCE:MULTIPLE
             >
             /bigobj
-            /STACK:16777216
             /MANIFEST:NO;
             /DEBUG;
             /SUBSYSTEM:CONSOLE
@@ -163,7 +161,6 @@ else()
                 /FORCE:MULTIPLE
             >
             /bigobj
-            /STACK:16777216
             /MANIFEST:NO;
             /DEBUG;
             /SUBSYSTEM:CONSOLE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,10 @@ endif()
 if (USE_STANDALONE)
     add_definitions(-DSTANDALONE)
     add_executable(${PROJECT_NAME} ${SRC_DIR})
+	set(LINK_TYPE "MD")
 else()
     add_library(${PROJECT_NAME} STATIC ${SRC_DIR})
+	set(LINK_TYPE "MT")
 endif()
 
 if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
@@ -99,13 +101,13 @@ else()
             $<$<CONFIG:Debug>:
                 /w;
                 /Od;
-                /MTd
+                /${LINK_TYPE}d
             >
             $<$<CONFIG:Release>:
                 /O3;
                 /Gy;
                 /W3;
-                /MT
+                /${LINK_TYPE}
             >
             /bigobj
             /STACK:16777216
@@ -118,13 +120,13 @@ else()
     elseif("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "Win32")
         target_compile_options(${PROJECT_NAME} PRIVATE
             $<$<CONFIG:Debug>:
-                /MTd
+                /${LINK_TYPE}d
             >
             $<$<CONFIG:Release>:
                 /O3;
                 /Oi;
                 /Gy;
-                /MT
+                /${LINK_TYPE}
             >
             /STACK:16777216
             /permissive-;

--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -1110,13 +1110,14 @@ void Companion::Process() {
             entries.push_back(key);
         }
     }
-
+#ifdef USE_STANDALONE
     if(cfg["enums"]) {
         auto enums = GetSafeNode<std::vector<std::string>>(cfg, "enums");
         for (auto& file : enums) {
             this->ParseEnums(file);
         }
     }
+#endif
 
     if(cfg["logging"]){
         auto level = cfg["logging"].as<std::string>();


### PR DESCRIPTION
Changes to Torch:better_lib to finish the process of enabling inclusion of Torch as a lib in ports on Windows. *Should* still work with other platforms, but is untested on them. Should also maintain the usability of TorchExternal and standalone usage.