### PR TITLE
Additional Texture Defines

### DIFF
--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -1150,6 +1150,8 @@ void Companion::Process() {
         }
     }
 
+    this->gConfig.textureDefines = cfg["textures"] && (cfg["textures"].as<std::string>() == "ADDITIONAL_DEFINES");
+
     this->ParseHash();
 
     SPDLOG_INFO("------------------------------------------------");

--- a/src/Companion.h
+++ b/src/Companion.h
@@ -89,6 +89,7 @@ struct TorchConfig {
     ArchiveType otrMode;
     bool debug;
     bool modding;
+    bool textureDefines;
 };
 
 struct ParseResultData {
@@ -115,6 +116,7 @@ public:
         this->gConfig.otrMode = otr;
         this->gConfig.debug = debug;
         this->gConfig.modding = modding;
+        this->gConfig.textureDefines = false;
     }
 
     explicit Companion(std::vector<uint8_t> rom, const ArchiveType otr, const bool debug, const bool modding = false) : gCartridge(nullptr) {
@@ -122,6 +124,7 @@ public:
         this->gConfig.otrMode = otr;
         this->gConfig.debug = debug;
         this->gConfig.modding = modding;
+        this->gConfig.textureDefines = false;
     }
 
     void Init(ExportType type);
@@ -132,6 +135,7 @@ public:
 
     bool IsOTRMode() const { return (this->gConfig.otrMode != ArchiveType::None); }
     bool IsDebug() const { return this->gConfig.debug; }
+    bool AddTextureDefines() const { return this->gConfig.textureDefines; }
 
     N64::Cartridge* GetCartridge() const { return this->gCartridge.get(); }
     std::vector<uint8_t>& GetRomData() { return this->gRomData; }

--- a/src/factories/CompressedTextureFactory.cpp
+++ b/src/factories/CompressedTextureFactory.cpp
@@ -68,6 +68,8 @@ ExportResult CompressedTextureHeaderExporter::Export(std::ostream &write, std::s
     } else {
         if(isOTR){
             write << "static const ALIGN_ASSET(2) char " << symbol << "[] = \"__OTR__" << (*replacement) << "\";\n\n";
+            write << "#define _" << symbol << "_WIDTH 0x" << std::hex << texture->mWidth << std::dec << "\n";
+            write << "#define _" << symbol << "_HEIGHT 0x" << std::hex << texture->mHeight << std::dec << "\n";
         } else {
             write << "extern " << "u8 " << symbol << "[];\n";
             // Allocate worse case size

--- a/src/factories/CompressedTextureFactory.cpp
+++ b/src/factories/CompressedTextureFactory.cpp
@@ -68,29 +68,33 @@ ExportResult CompressedTextureHeaderExporter::Export(std::ostream &write, std::s
     } else {
         if(isOTR){
             write << "static const ALIGN_ASSET(2) char " << symbol << "[] = \"__OTR__" << (*replacement) << "\";\n\n";
-            write << "#define _" << symbol << "_WIDTH 0x" << std::hex << texture->mWidth << std::dec << "\n";
-            write << "#define _" << symbol << "_HEIGHT 0x" << std::hex << texture->mHeight << std::dec << "\n";
+            if (Companion::Instance->AddTextureDefines()) {
+                write << "#define _" << symbol << "_WIDTH 0x" << std::hex << texture->mWidth << std::dec << "\n";
+                write << "#define _" << symbol << "_HEIGHT 0x" << std::hex << texture->mHeight << std::dec << "\n";
+            }
         } else {
             write << "extern " << "u8 " << symbol << "[];\n";
-            // Allocate worse case size
-            uint8_t* compressedData;
-            size_t compressedSize;
-            size_t worstSize;
+            if (Companion::Instance->AddTextureDefines()) {
+                // Allocate worse case size
+                uint8_t* compressedData;
+                size_t compressedSize;
+                size_t worstSize;
 
-            switch (texture->mCompressionType) {
-                case CompressionType::MIO0:
-                    worstSize = MIO0_HEADER_LENGTH + ((data.size()+7)/8) + data.size();
-                    compressedData = static_cast<uint8_t*>(std::calloc(worstSize, sizeof(uint8_t)));
-                    compressedSize = mio0_encode(data.data(), data.size(), compressedData);
-                    break;
-                default:
-                    // UNIMPLEMENTED
-                    throw std::runtime_error("Unsupported Compressed Texture Type");
-                    break;
+                switch (texture->mCompressionType) {
+                    case CompressionType::MIO0:
+                        worstSize = MIO0_HEADER_LENGTH + ((data.size()+7)/8) + data.size();
+                        compressedData = static_cast<uint8_t*>(std::calloc(worstSize, sizeof(uint8_t)));
+                        compressedSize = mio0_encode(data.data(), data.size(), compressedData);
+                        break;
+                    default:
+                        // UNIMPLEMENTED
+                        throw std::runtime_error("Unsupported Compressed Texture Type");
+                        break;
+                }
+                write << "#define _" << symbol << "_COMPRESSED_SIZE 0x" << std::hex << compressedSize << std::dec << "\n";
+                write << "#define _" << symbol << "_WIDTH 0x" << std::hex << texture->mWidth << std::dec << "\n";
+                write << "#define _" << symbol << "_HEIGHT 0x" << std::hex << texture->mHeight << std::dec << "\n";
             }
-            write << "#define _" << symbol << "_COMPRESSED_SIZE 0x" << std::hex << compressedSize << std::dec << "\n";
-            write << "#define _" << symbol << "_WIDTH 0x" << std::hex << texture->mWidth << std::dec << "\n";
-            write << "#define _" << symbol << "_HEIGHT 0x" << std::hex << texture->mHeight << std::dec << "\n";
         }
     }
 

--- a/src/factories/TextureFactory.cpp
+++ b/src/factories/TextureFactory.cpp
@@ -57,12 +57,12 @@ ExportResult TextureHeaderExporter::Export(std::ostream &write, std::shared_ptr<
             }
         } else {
             write << "extern " << GetSafeNode<std::string>(node, "ctype", "u8") << " " << name << "[][" << isize << "];\n";
-            write << "#define _" << symbol << "_WIDTH 0x" << std::hex << texture->mWidth << std::dec << "\n";
-            write << "#define _" << symbol << "_HEIGHT 0x" << std::hex << texture->mHeight << std::dec << "\n";
         }
     } else {
         if(isOTR){
             write << "static const ALIGN_ASSET(2) char " << symbol << "[] = \"__OTR__" << (*replacement) << "\";\n\n";
+            write << "#define _" << symbol << "_WIDTH 0x" << std::hex << texture->mWidth << std::dec << "\n";
+            write << "#define _" << symbol << "_HEIGHT 0x" << std::hex << texture->mHeight << std::dec << "\n";
         } else {
             write << "extern " << GetSafeNode<std::string>(node, "ctype", "u8") << " " << symbol << "[];\n";
             write << "#define _" << symbol << "_WIDTH 0x" << std::hex << texture->mWidth << std::dec << "\n";

--- a/src/factories/TextureFactory.cpp
+++ b/src/factories/TextureFactory.cpp
@@ -57,12 +57,16 @@ ExportResult TextureHeaderExporter::Export(std::ostream &write, std::shared_ptr<
             }
         } else {
             write << "extern " << GetSafeNode<std::string>(node, "ctype", "u8") << " " << name << "[][" << isize << "];\n";
+            write << "#define _" << symbol << "_WIDTH 0x" << std::hex << texture->mWidth << std::dec << "\n";
+            write << "#define _" << symbol << "_HEIGHT 0x" << std::hex << texture->mHeight << std::dec << "\n";
         }
     } else {
         if(isOTR){
             write << "static const ALIGN_ASSET(2) char " << symbol << "[] = \"__OTR__" << (*replacement) << "\";\n\n";
         } else {
             write << "extern " << GetSafeNode<std::string>(node, "ctype", "u8") << " " << symbol << "[];\n";
+            write << "#define _" << symbol << "_WIDTH 0x" << std::hex << texture->mWidth << std::dec << "\n";
+            write << "#define _" << symbol << "_HEIGHT 0x" << std::hex << texture->mHeight << std::dec << "\n";
         }
     }
 

--- a/src/factories/TextureFactory.cpp
+++ b/src/factories/TextureFactory.cpp
@@ -61,12 +61,16 @@ ExportResult TextureHeaderExporter::Export(std::ostream &write, std::shared_ptr<
     } else {
         if(isOTR){
             write << "static const ALIGN_ASSET(2) char " << symbol << "[] = \"__OTR__" << (*replacement) << "\";\n\n";
-            write << "#define _" << symbol << "_WIDTH 0x" << std::hex << texture->mWidth << std::dec << "\n";
-            write << "#define _" << symbol << "_HEIGHT 0x" << std::hex << texture->mHeight << std::dec << "\n";
+            if (Companion::Instance->AddTextureDefines()) {
+                write << "#define _" << symbol << "_WIDTH 0x" << std::hex << texture->mWidth << std::dec << "\n";
+                write << "#define _" << symbol << "_HEIGHT 0x" << std::hex << texture->mHeight << std::dec << "\n";
+            }
         } else {
             write << "extern " << GetSafeNode<std::string>(node, "ctype", "u8") << " " << symbol << "[];\n";
-            write << "#define _" << symbol << "_WIDTH 0x" << std::hex << texture->mWidth << std::dec << "\n";
-            write << "#define _" << symbol << "_HEIGHT 0x" << std::hex << texture->mHeight << std::dec << "\n";
+            if (Companion::Instance->AddTextureDefines()) {
+                write << "#define _" << symbol << "_WIDTH 0x" << std::hex << texture->mWidth << std::dec << "\n";
+                write << "#define _" << symbol << "_HEIGHT 0x" << std::hex << texture->mHeight << std::dec << "\n";
+            }
         }
     }
 


### PR DESCRIPTION
This adds texture defines to width and height (and compressed size for compressed textures)

This helps with version support where textures will change in various ways. The general idea is to then have the following macros in a decomp project:

```cpp
#define TEX_COMPRESSED_SIZE(tex) (_ ## tex ## _COMPRESSED_SIZE)
#define TEX_WIDTH(tex) (_ ## tex ## _WIDTH)
#define TEX_HEIGHT(tex) (_ ## tex ## _HEIGHT)
#define TEX_SIZE(tex, depth) (TEX_WIDTH(tex) * TEX_HEIGHT(tex) * (depth))
#define TEX_SIZE_4B(tex) (TEX_WIDTH(tex) * TEX_HEIGHT(tex) / 2)
```

Happy to put this behind some kind of global config but wasnt quite sure yet on how to approach that