### PR TITLE
Lowered the min cmake version required to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.12)
 project(torch)
 include(FetchContent)
 


### PR DESCRIPTION
Having the min requirement at 3.30 breaks windows builds, 3.12 is still above 3.5 so it should still work on 4.0 and works with windows builds.