### PR TITLE
Add MA2D1 Factory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(BUILD_SM64 "Build with Super Mario 64 support" ON)
 option(BUILD_MK64 "Build with Mario Kart 64 support" ON)
 option(BUILD_SF64 "Build with Star Fox 64 support" ON)
 option(BUILD_FZERO "Build with F-Zero X support" ON)
+option(BUILD_MARIO_ARTIST "Build with Mario Artist support" ON)
 option(BUILD_NAUDIO "Build with NAudio support" ON)
 
 ################################################################################
@@ -82,6 +83,12 @@ if(BUILD_FZERO)
     add_definitions(-DFZERO_SUPPORT)
 else()
     list(FILTER SRC_DIR EXCLUDE REGEX "${CMAKE_CURRENT_SOURCE_DIR}/src/factories/fzerox/*")
+endif()
+
+if(BUILD_MARIO_ARTIST)
+    add_definitions(-DMARIO_ARTIST_SUPPORT)
+else()
+    list(FILTER SRC_DIR EXCLUDE REGEX "${CMAKE_CURRENT_SOURCE_DIR}/src/factories/mario_artist/*")
 endif()
 
 if(BUILD_NAUDIO)

--- a/lib/libyay0/yay0.h
+++ b/lib/libyay0/yay0.h
@@ -2,4 +2,7 @@
 
 #include <stdint.h>
 
+#define YAY0_HEADER_LENGTH 16
+
+extern int32_t yay0_encode(const uint8_t *in_buf, uint32_t length, uint8_t* out_buf);
 extern uint8_t* yay0_decode(const uint8_t* in, uint32_t* out_size);

--- a/lib/libyay0/yay1.c
+++ b/lib/libyay0/yay1.c
@@ -1,4 +1,4 @@
-#include "yay0.h"
+#include "yay1.h"
 #include "libmio0/utils.h"
 #include <string.h>
 #include <stdlib.h>
@@ -117,7 +117,7 @@ static int find_longest(const unsigned char *buf, int start_offset, int max_sear
    return best_length;
 }
 
-int32_t yay0_encode(const uint8_t *in_buf, uint32_t length, uint8_t* out_buf) {
+int32_t yay1_encode(const uint8_t *in_buf, uint32_t length, uint8_t* out_buf) {
     unsigned char *bit_buf;
     unsigned char *comp_buf;
     unsigned char *uncomp_buf;
@@ -195,17 +195,17 @@ int32_t yay0_encode(const uint8_t *in_buf, uint32_t length, uint8_t* out_buf) {
     // +7 so int division accounts for all bits
     bit_length = ((bit_idx + 7) / 8);
     // compressed data after control bits and aligned to 4-byte boundary
-    comp_offset = ALIGN(YAY0_HEADER_LENGTH + bit_length, 4);
+    comp_offset = ALIGN(YAY1_HEADER_LENGTH + bit_length, 4);
     uncomp_offset = comp_offset + comp_idx;
     bytes_written = uncomp_offset + uncomp_idx;
  
     // output header
-    memcpy(out_buf, "Yay0", 4);
+    memcpy(out_buf, "Yay1", 4);
     write_u32_be(&out_buf[4], length);
     write_u32_be(&out_buf[8], comp_offset);
     write_u32_be(&out_buf[12], uncomp_offset);
     // output data
-    memcpy(&out_buf[YAY0_HEADER_LENGTH], bit_buf, bit_length);
+    memcpy(&out_buf[YAY1_HEADER_LENGTH], bit_buf, bit_length);
     memcpy(&out_buf[comp_offset], comp_buf, comp_idx);
     memcpy(&out_buf[uncomp_offset], uncomp_buf, uncomp_idx);
  
@@ -218,17 +218,11 @@ int32_t yay0_encode(const uint8_t *in_buf, uint32_t length, uint8_t* out_buf) {
     return bytes_written;
 }
 
-uint8_t* yay0_decode(const uint8_t* in_buf, uint32_t* out_size){
+uint8_t* yay1_decode(const uint8_t* in_buf, uint32_t* out_size){
 
     const uint8_t* in = in_buf;
-    const char* magic = (const char*) in;
-    if(!strncmp(magic, "PERS-SZP", 8)){
-        uint32_t header_size = read_u32_be(in + 8);
-        magic += header_size;
-        in += header_size;
-    }
 
-    if(strncmp(magic, "Yay0", 4) != 0){
+    if(strncmp(in, "Yay1", 4) != 0){
         return NULL;
     }
 

--- a/lib/libyay0/yay1.h
+++ b/lib/libyay0/yay1.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <stdint.h>
+
+#define YAY1_HEADER_LENGTH 16
+
+extern int32_t yay1_encode(const uint8_t *in_buf, uint32_t length, uint8_t* out_buf);
+extern uint8_t* yay1_decode(const uint8_t* in, uint32_t* out_size);

--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -75,6 +75,10 @@
 #include "factories/fzerox/GhostRecordFactory.h"
 #endif
 
+#ifdef MARIO_ARTIST_SUPPORT
+#include "factories/mario_artist/MA2D1Factory.h"
+#endif
+
 #ifdef NAUDIO_SUPPORT
 #include "factories/naudio/v0/AudioHeaderFactory.h"
 #include "factories/naudio/v0/BankFactory.h"
@@ -167,6 +171,10 @@ void Companion::Init(const ExportType type) {
 #ifdef FZERO_SUPPORT
     this->RegisterFactory("FZX:COURSE", std::make_shared<FZX::CourseFactory>());
     this->RegisterFactory("FZX:GHOST", std::make_shared<FZX::GhostRecordFactory>());
+#endif
+
+#ifdef MARIO_ARTIST_SUPPORT
+    this->RegisterFactory("MA:MA2D1", std::make_shared<MA::MA2D1Factory>());
 #endif
 
 #ifdef NAUDIO_SUPPORT

--- a/src/factories/mario_artist/MA2D1Factory.cpp
+++ b/src/factories/mario_artist/MA2D1Factory.cpp
@@ -1,0 +1,107 @@
+#include "MA2D1Factory.h"
+#include "spdlog/spdlog.h"
+
+#include "Companion.h"
+#include "utils/Decompressor.h"
+#include "utils/TorchUtils.h"
+
+ExportResult MA::MA2D1HeaderExporter::Export(std::ostream &write, std::shared_ptr<IParsedData> raw, std::string& entryName, YAML::Node &node, std::string* replacement) {
+    const auto symbol = GetSafeNode(node, "symbol", entryName);
+
+    return std::nullopt;
+}
+
+ExportResult MA::MA2D1CodeExporter::Export(std::ostream &write, std::shared_ptr<IParsedData> raw, std::string& entryName, YAML::Node &node, std::string* replacement ) {
+    const auto symbol = GetSafeNode(node, "symbol", entryName);
+    const auto offset = GetSafeNode<uint32_t>(node, "offset");
+    const auto data = std::static_pointer_cast<MA2D1Data>(raw);
+
+    write << "char " << symbol << "_header" << "[] = { ";
+
+    for (size_t i = 0; i < data->mFormat.size(); i++) {
+        if (i != 0) {
+            write << ", ";
+        }
+
+        write << "\'" << data->mFormat.at(i) << "\'";
+    }
+
+    write << ", \'" << ((data->mWidth / 100) % 10) << "\'";
+    write << ", \'" << ((data->mWidth / 10) % 10) << "\'";
+    write << ", \'" << ((data->mWidth / 1) % 10) << "\'";
+
+    write << ", \'" << ((data->mHeight / 100) % 10) << "\'";
+    write << ", \'" << ((data->mHeight / 10) % 10) << "\'";
+    write << ", \'" << ((data->mHeight / 1) % 10) << "\'";
+
+    write << ", \'" << ((data->mSize / 100000) % 10) << "\'";
+    write << ", \'" << ((data->mSize / 10000) % 10) << "\'";
+    write << ", \'" << ((data->mSize / 1000) % 10) << "\'";
+    write << ", \'" << ((data->mSize / 100) % 10) << "\'";
+    write << ", \'" << ((data->mSize / 10) % 10) << "\'";
+    write << ", \'" << ((data->mSize / 1) % 10) << "\'";
+
+    write << " };\n\n";
+
+    return offset + 0x10;
+}
+
+ExportResult MA::MA2D1BinaryExporter::Export(std::ostream &write, std::shared_ptr<IParsedData> raw, std::string& entryName, YAML::Node &node, std::string* replacement ) {
+    // Nothing Required Here For Binary Exporting
+
+    return std::nullopt;
+}
+
+std::optional<std::shared_ptr<IParsedData>> MA::MA2D1Factory::parse(std::vector<uint8_t>& buffer, YAML::Node& node) {
+    auto [_, segment] = Decompressor::AutoDecode(node, buffer);
+    const auto offset = GetSafeNode<uint32_t>(node, "offset");
+    const auto symbol = GetSafeNode<std::string>(node, "symbol");
+    LUS::BinaryReader reader(segment.data, segment.size);
+
+    reader.SetEndianness(Torch::Endianness::Big);
+
+    YAML::Node thumbnail;
+    thumbnail["type"] = "TEXTURE";
+    thumbnail["ctype"] = "u16";
+    thumbnail["format"] = "RGBA16";
+    thumbnail["width"] = 24;
+    thumbnail["height"] = 24;
+    thumbnail["offset"] = offset;
+    thumbnail["symbol"] = symbol + "_thumb";
+    Companion::Instance->AddAsset(thumbnail);
+
+    reader.Seek(0x480, LUS::SeekOffsetType::Start);
+
+    char headerBuffer[0x10];
+
+    for (size_t i = 0; i < sizeof(headerBuffer); i++) {
+        headerBuffer[i] = reader.ReadChar();
+    }
+
+    // Override offset
+    node["offset"] = offset + 0x480;
+
+    std::string format(headerBuffer, headerBuffer + 4);
+
+    uint32_t width = std::stoi(std::string(headerBuffer + 4, 3));
+    uint32_t height = std::stoi(std::string(headerBuffer + 7, 3));
+    uint32_t size = std::stoi(std::string(headerBuffer + 10, 6));
+
+    YAML::Node image;
+    if (format == "NCMP") {
+        image["type"] = "COMPRESSED_TEXTURE";
+        image["compression"] = "YAY1";
+    } else {
+        image["type"] = "TEXTURE";
+    }
+
+    image["ctype"] = "u16";
+    image["format"] = "RGBA16";
+    image["width"] = width;
+    image["height"] = height;
+    image["offset"] = offset + 0x490;
+    image["symbol"] = symbol + "_image";
+    Companion::Instance->AddAsset(image);
+
+    return std::make_shared<MA2D1Data>(format, width, height, size);
+}

--- a/src/factories/mario_artist/MA2D1Factory.h
+++ b/src/factories/mario_artist/MA2D1Factory.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <factories/BaseFactory.h>
+
+namespace MA {
+
+class MA2D1Data : public IParsedData {
+public:
+    std::string mFormat;
+    uint32_t mWidth;
+    uint32_t mHeight;
+    uint32_t mSize;
+
+    MA2D1Data(std::string format, uint32_t width, uint32_t height, uint32_t size) : 
+        mFormat(format),
+        mWidth(width),
+        mHeight(height),
+        mSize(size) {}
+};
+
+class MA2D1HeaderExporter : public BaseExporter {
+    ExportResult Export(std::ostream& write, std::shared_ptr<IParsedData> data, std::string& entryName, YAML::Node& node, std::string* replacement) override;
+};
+
+class MA2D1BinaryExporter : public BaseExporter {
+    ExportResult Export(std::ostream& write, std::shared_ptr<IParsedData> data, std::string& entryName, YAML::Node& node, std::string* replacement) override;
+};
+
+class MA2D1CodeExporter : public BaseExporter {
+    ExportResult Export(std::ostream& write, std::shared_ptr<IParsedData> data, std::string& entryName, YAML::Node& node, std::string* replacement) override;
+};
+
+class MA2D1Factory : public BaseFactory {
+public:
+    std::optional<std::shared_ptr<IParsedData>> parse(std::vector<uint8_t>& buffer, YAML::Node& data) override;
+    inline std::unordered_map<ExportType, std::shared_ptr<BaseExporter>> GetExporters() override {
+        return {
+            REGISTER(Code, MA2D1CodeExporter)
+            REGISTER(Header, MA2D1HeaderExporter)
+            REGISTER(Binary, MA2D1BinaryExporter)
+        };
+    }
+    bool HasModdedDependencies() override { return true; }
+};
+}

--- a/src/utils/Decompressor.h
+++ b/src/utils/Decompressor.h
@@ -12,6 +12,7 @@ enum class CompressionType {
     None,
     MIO0,
     YAY0,
+    YAY1,
     YAZ0,
 };
 


### PR DESCRIPTION
Adds extraction support for the ma2d1 file format used by mario artist

This also adds yay0 and yay1 encoding support (as well as yay1 decoding).