### PR TITLE
Add configurable src and dest paths

### DIFF
--- a/src/Companion.h
+++ b/src/Companion.h
@@ -112,7 +112,9 @@ class Companion {
 public:
     static Companion* Instance;
 
-    explicit Companion(std::filesystem::path rom, const ArchiveType otr, const bool debug, const bool modding = false) : gCartridge(nullptr) {
+    explicit Companion(std::filesystem::path rom, const ArchiveType otr, const bool debug, const bool modding = false,
+                       const std::string& srcDir = "", const std::string& destPath = "") : gCartridge(nullptr),
+                       gSourceDirectory(srcDir), gDestinationPath(destPath) {
         this->gRomPath = rom;
         this->gConfig.otrMode = otr;
         this->gConfig.debug = debug;
@@ -120,13 +122,21 @@ public:
         this->gConfig.textureDefines = false;
     }
 
-    explicit Companion(std::vector<uint8_t> rom, const ArchiveType otr, const bool debug, const bool modding = false) : gCartridge(nullptr) {
+    explicit Companion(std::vector<uint8_t> rom, const ArchiveType otr, const bool debug, const bool modding = false,
+                       const std::string& srcDir = "", const std::string& destPath = "") : gCartridge(nullptr),
+                       gSourceDirectory(srcDir), gDestinationPath(destPath) {
         this->gRomData = rom;
         this->gConfig.otrMode = otr;
         this->gConfig.debug = debug;
         this->gConfig.modding = modding;
         this->gConfig.textureDefines = false;
     }
+
+    explicit Companion(std::filesystem::path rom, const ArchiveType otr, const bool debug, const std::string& srcDir = "", const std::string& destPath = "") :
+                       Companion(rom, otr, debug, false, srcDir, destPath) {}
+
+    explicit Companion(std::vector<uint8_t> rom, const ArchiveType otr, const bool debug, const std::string& srcDir = "", const std::string& destPath = "") :
+                       Companion(rom, otr, debug, false, srcDir, destPath) {}
 
     void Init(ExportType type);
 
@@ -179,6 +189,8 @@ public:
 private:
     TorchConfig gConfig;
     YAML::Node gModdingConfig;
+    fs::path gSourceDirectory;
+    fs::path gDestinationPath;
     fs::path gCurrentDirectory;
     std::string gCurrentHash;
     std::string gAssetPath;

--- a/src/Companion.h
+++ b/src/Companion.h
@@ -114,7 +114,7 @@ public:
 
     explicit Companion(std::filesystem::path rom, const ArchiveType otr, const bool debug, const bool modding = false,
                        const std::string& srcDir = "", const std::string& destPath = "") : gCartridge(nullptr),
-                       gSourceDirectory(srcDir), gDestinationPath(destPath) {
+                       gSourceDirectory(srcDir), gDestinationDirectory(destPath) {
         this->gRomPath = rom;
         this->gConfig.otrMode = otr;
         this->gConfig.debug = debug;
@@ -124,7 +124,7 @@ public:
 
     explicit Companion(std::vector<uint8_t> rom, const ArchiveType otr, const bool debug, const bool modding = false,
                        const std::string& srcDir = "", const std::string& destPath = "") : gCartridge(nullptr),
-                       gSourceDirectory(srcDir), gDestinationPath(destPath) {
+                       gSourceDirectory(srcDir), gDestinationDirectory(destPath) {
         this->gRomData = rom;
         this->gConfig.otrMode = otr;
         this->gConfig.debug = debug;
@@ -151,6 +151,7 @@ public:
     N64::Cartridge* GetCartridge() const { return this->gCartridge.get(); }
     std::vector<uint8_t>& GetRomData() { return this->gRomData; }
     std::string GetOutputPath() { return this->gConfig.outputPath; }
+    std::string GetDestRelativeOutputPath() { return RelativePathToDestDir(GetOutputPath()); }
 
     GBIVersion GetGBIVersion() const { return this->gConfig.gbi.version; }
     GBIMinorVersion GetGBIMinorVersion() const { return  this->gConfig.gbi.subversion; }
@@ -179,6 +180,8 @@ public:
     static void Pack(const std::string& folder, const std::string& output, const ArchiveType otrMode);
     std::string NormalizeAsset(const std::string& name) const;
     std::string RelativePath(const std::string& path) const;
+    std::string RelativePathToSrcDir(const std::string& path) const;
+    std::string RelativePathToDestDir(const std::string& path) const;
     void RegisterCompanionFile(const std::string path, std::vector<char> data);
 
     TorchConfig& GetConfig() { return this->gConfig; }
@@ -190,7 +193,7 @@ private:
     TorchConfig gConfig;
     YAML::Node gModdingConfig;
     fs::path gSourceDirectory;
-    fs::path gDestinationPath;
+    fs::path gDestinationDirectory;
     fs::path gCurrentDirectory;
     std::string gCurrentHash;
     std::string gAssetPath;

--- a/src/factories/CompressedTextureFactory.cpp
+++ b/src/factories/CompressedTextureFactory.cpp
@@ -218,7 +218,7 @@ ExportResult CompressedTextureCodeExporter::Export(std::ostream &write, std::sha
 
         write << tab_t << "{\n";
 
-        write << tab_t << tab_t << "#include \"" << Companion::Instance->GetOutputPath() + "/" << *replacement << ".incbin.c\"\n";
+        write << tab_t << tab_t << "#include \"" << Companion::Instance->GetDestRelativeOutputPath() + "/" << *replacement << ".incbin.c\"\n";
 
         write << tab_t << "},\n";
 
@@ -231,7 +231,7 @@ ExportResult CompressedTextureCodeExporter::Export(std::ostream &write, std::sha
     } else {
         write << "u8 " << symbol  << "[] = {\n";
 
-        write << tab_t << "#include \"" << Companion::Instance->GetOutputPath() + "/" << *replacement << ".incbin.c\"\n";
+        write << tab_t << "#include \"" << Companion::Instance->GetDestRelativeOutputPath() + "/" << *replacement << ".incbin.c\"\n";
 
         write << "};\n";
 

--- a/src/factories/TextureFactory.cpp
+++ b/src/factories/TextureFactory.cpp
@@ -137,7 +137,7 @@ ExportResult TextureCodeExporter::Export(std::ostream &write, std::shared_ptr<IP
 
         write << tab_t << "{\n";
         if (!Companion::Instance->IsUsingIndividualIncludes()){
-            write << tab_t << tab_t << "#include \"" << Companion::Instance->GetOutputPath() + "/" << *replacement << ".inc.c\"\n";
+            write << tab_t << tab_t << "#include \"" << Companion::Instance->GetDestRelativeOutputPath() + "/" << *replacement << ".inc.c\"\n";
         } else {
             write << imgstream.str();
         }
@@ -153,7 +153,7 @@ ExportResult TextureCodeExporter::Export(std::ostream &write, std::shared_ptr<IP
         write << GetSafeNode<std::string>(node, "ctype", "u8") << " " << symbol  << "[] = {\n";
 
         if (!Companion::Instance->IsUsingIndividualIncludes()){
-            write << tab_t << "#include \"" << Companion::Instance->GetOutputPath() + "/" << *replacement << ".inc.c\"\n";
+            write << tab_t << "#include \"" << Companion::Instance->GetDestRelativeOutputPath() + "/" << *replacement << ".inc.c\"\n";
         } else {
             write << imgstream.str();
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,8 +20,13 @@ int main(int argc, char *argv[]) {
     bool otrModeSelected = false;
     bool xmlMode = false;
     bool debug = false;
+    std::string srcdir;
+    std::string destdir
 
     app.require_subcommand();
+
+    app.add_option("-s", "--srcdir", srcdir, "Set source directory to locate config.yml, asset metadata, and modding files for importing");
+    app.add_option("-d", "--destdir", destdir, "Set destination directory for exporting and generating binaries and source code");
 
     /* Generate an OTR */
     const auto otr = app.add_subcommand("otr", "OTR - Generates an otr\n");
@@ -30,7 +35,7 @@ int main(int argc, char *argv[]) {
     otr->add_flag("-v,--verbose", debug, "Verbose Debug Mode");
 
     otr->parse_complete_callback([&] {
-        const auto instance = Companion::Instance = new Companion(filename, ArchiveType::OTR, debug);
+        const auto instance = Companion::Instance = new Companion(filename, ArchiveType::OTR, debug, srcdir, destdir);
         instance->Init(ExportType::Binary);
     });
 
@@ -41,7 +46,7 @@ int main(int argc, char *argv[]) {
     o2r->add_flag("-v,--verbose", debug, "Verbose Debug Mode");
 
     o2r->parse_complete_callback([&] {
-        const auto instance = Companion::Instance = new Companion(filename, ArchiveType::O2R, debug);
+        const auto instance = Companion::Instance = new Companion(filename, ArchiveType::O2R, debug, srcdir, destdir);
         instance->Init(ExportType::Binary);
     });
 
@@ -52,7 +57,7 @@ int main(int argc, char *argv[]) {
     code->add_flag("-v,--verbose", debug, "Verbose Debug Mode; adds offsets to C code");
 
     code->parse_complete_callback([&]() {
-        const auto instance = Companion::Instance = new Companion(filename, ArchiveType::None, debug);
+        const auto instance = Companion::Instance = new Companion(filename, ArchiveType::None, debug, srcdir, destdir);
         instance->Init(ExportType::Code);
     });
 
@@ -62,7 +67,7 @@ int main(int argc, char *argv[]) {
     binary->add_option("<baserom.z64>", filename, "")->required()->check(CLI::ExistingFile);
 
     binary->parse_complete_callback([&] {
-        const auto instance = Companion::Instance = new Companion(filename, ArchiveType::None, debug);
+        const auto instance = Companion::Instance = new Companion(filename, ArchiveType::None, debug, srcdir, destdir);
         instance->Init(ExportType::Binary);
     });
 
@@ -80,7 +85,7 @@ int main(int argc, char *argv[]) {
             otrMode = ArchiveType::None;
         }
 
-        const auto instance = Companion::Instance = new Companion(filename, otrMode, debug);
+        const auto instance = Companion::Instance = new Companion(filename, otrMode, debug, srcdir, destdir);
         instance->Init(ExportType::Header);
     });
 
@@ -128,7 +133,7 @@ int main(int argc, char *argv[]) {
             otrMode = ArchiveType::None;
         }
 
-        const auto instance = Companion::Instance = new Companion(filename, otrMode, debug, true);
+        const auto instance = Companion::Instance = new Companion(filename, otrMode, debug, true, srcdir, destdir);
         if (mode == "code") {
             instance->Init(ExportType::Code);
         } else if (mode == "otr" || mode == "o2r") {
@@ -144,7 +149,7 @@ int main(int argc, char *argv[]) {
     modding_export->add_option("<baserom.z64>", filename, "")->required()->check(CLI::ExistingFile);
 
     modding_export->parse_complete_callback([&] {
-        const auto instance = Companion::Instance = new Companion(filename, ArchiveType::None, debug);
+        const auto instance = Companion::Instance = new Companion(filename, ArchiveType::None, debug, srcdir, destdir);
         if (xmlMode) {
             instance->Init(ExportType::XML);
         } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,18 +21,17 @@ int main(int argc, char *argv[]) {
     bool xmlMode = false;
     bool debug = false;
     std::string srcdir;
-    std::string destdir
+    std::string destdir;
 
     app.require_subcommand();
-
-    app.add_option("-s", "--srcdir", srcdir, "Set source directory to locate config.yml, asset metadata, and modding files for importing");
-    app.add_option("-d", "--destdir", destdir, "Set destination directory for exporting and generating binaries and source code");
 
     /* Generate an OTR */
     const auto otr = app.add_subcommand("otr", "OTR - Generates an otr\n");
 
     otr->add_option("<baserom.z64>", filename, "")->required()->check(CLI::ExistingFile);
     otr->add_flag("-v,--verbose", debug, "Verbose Debug Mode");
+    otr->add_option("-s,--srcdir", srcdir, "Set source directory to locate config.yml and asset metadata for processing")->check(CLI::ExistingDirectory);
+    otr->add_option("-d,--destdir", destdir, "Set destination directory for export");
 
     otr->parse_complete_callback([&] {
         const auto instance = Companion::Instance = new Companion(filename, ArchiveType::OTR, debug, srcdir, destdir);
@@ -44,6 +43,8 @@ int main(int argc, char *argv[]) {
 
     o2r->add_option("<baserom.z64>", filename, "")->required()->check(CLI::ExistingFile);
     o2r->add_flag("-v,--verbose", debug, "Verbose Debug Mode");
+    o2r->add_option("-s,--srcdir", srcdir, "Set source directory to locate config.yml and asset metadata for processing")->check(CLI::ExistingDirectory);
+    o2r->add_option("-d,--destdir", destdir, "Set destination directory for export");
 
     o2r->parse_complete_callback([&] {
         const auto instance = Companion::Instance = new Companion(filename, ArchiveType::O2R, debug, srcdir, destdir);
@@ -55,6 +56,8 @@ int main(int argc, char *argv[]) {
 
     code->add_option("<baserom.z64>", filename, "")->required()->check(CLI::ExistingFile);
     code->add_flag("-v,--verbose", debug, "Verbose Debug Mode; adds offsets to C code");
+    code->add_option("-s,--srcdir", srcdir, "Set source directory to locate config.yml and asset metadata for processing")->check(CLI::ExistingDirectory);
+    code->add_option("-d,--destdir", destdir, "Set destination directory to place C code to");
 
     code->parse_complete_callback([&]() {
         const auto instance = Companion::Instance = new Companion(filename, ArchiveType::None, debug, srcdir, destdir);
@@ -65,6 +68,8 @@ int main(int argc, char *argv[]) {
     const auto binary = app.add_subcommand("binary", "Binary - Generates a binary\n");
 
     binary->add_option("<baserom.z64>", filename, "")->required()->check(CLI::ExistingFile);
+    binary->add_option("-s,--srcdir", srcdir, "Set source directory to locate config.yml and asset metadata for processing")->check(CLI::ExistingDirectory);
+    binary->add_option("-d,--destdir", destdir, "Set destination directory to place binary to");
 
     binary->parse_complete_callback([&] {
         const auto instance = Companion::Instance = new Companion(filename, ArchiveType::None, debug, srcdir, destdir);
@@ -76,7 +81,8 @@ int main(int argc, char *argv[]) {
 
     header->add_option("<baserom.z64>", filename, "")->required()->check(CLI::ExistingFile);
     header->add_flag("-o,--otr", otrModeSelected, "OTR/O2R Mode");
-
+    header->add_option("-s,--srcdir", srcdir, "Set source directory to locate config.yml and asset metadata for processing")->check(CLI::ExistingDirectory);
+    header->add_option("-d,--destdir", destdir, "Set destination directory to place headers to");
 
     header->parse_complete_callback([&] {
         if (otrModeSelected) {
@@ -121,6 +127,8 @@ int main(int argc, char *argv[]) {
     modding_import->add_option("mode", mode, "code, otr, o2r or header")->required();
     modding_import->add_option("<baserom.z64>", filename, "")->required()->check(CLI::ExistingFile);
     modding_import->add_flag("-v,--verbose", debug, "Verbose Debug Mode");
+    modding_import->add_option("-s,--srcdir", srcdir, "Set source directory to locate config.yml and asset metadata for processing, including modified files")->check(CLI::ExistingDirectory);
+    modding_import->add_option("-d,--destdir", destdir, "Set destination directory to place for generating C code");
 
     modding_import->parse_complete_callback([&] {
         ArchiveType otrMode;
@@ -147,6 +155,8 @@ int main(int argc, char *argv[]) {
 
     modding_export->add_flag("-x,--xml", xmlMode, "XML Mode");
     modding_export->add_option("<baserom.z64>", filename, "")->required()->check(CLI::ExistingFile);
+    modding_export->add_option("-s,--srcdir", srcdir, "Set source directory to locate config.yml and asset metadata for processing, including modified files")->check(CLI::ExistingDirectory);
+    modding_export->add_option("-d,--destdir", destdir, "Set destination directory to place for generating modified files");
 
     modding_export->parse_complete_callback([&] {
         const auto instance = Companion::Instance = new Companion(filename, ArchiveType::None, debug, srcdir, destdir);


### PR DESCRIPTION
This adds configurable source and destination paths at the initialization procedure by instructing what path to find config and asset metadata and to generate output without modifying the config. This eliminates any extra file organizing workaround outside of Torch library/executable (moving the exported file or changing working directory before processing). This in conjunction with OTR/O2R archive generation for ports made with libultraship makes it more dynamic on special occasions.