### PR TITLE
BK: suppress extraction warnings per port policy

### DIFF
--- a/src/factories/bk64/ConfigFactory.cpp
+++ b/src/factories/bk64/ConfigFactory.cpp
@@ -443,6 +443,21 @@ RomhackKind ClassifyRomhack(const std::vector<uint8_t>& rom) {
 // Public wrapper: thin bool-returning view used by Lighthouse to gate UI before
 // running the rest of extraction. Same detection logic as DetectCustomCodeBlob
 // above; we discard the returned metadata for callers that just want a yes/no.
+bool GetCustomCodeBlobInfo(const std::vector<uint8_t>& rom, CustomCodeKind& outKind, char outSha1Hex[41]) {
+    uint32_t blobRom = 0, firstTarget = 0, ramBase = 0;
+    int jalCount = 0;
+    uint8_t sha1[20] = {};
+    outKind = CustomCodeKind::NONE;
+    outSha1Hex[0] = '\0';
+    if (!DetectCustomCodeBlob(rom, blobRom, jalCount, firstTarget, ramBase, outKind, sha1)) {
+        return false;
+    }
+    for (int i = 0; i < 20; i++) {
+        std::snprintf(outSha1Hex + i * 2, 3, "%02x", sha1[i]);
+    }
+    return true;
+}
+
 bool HasCustomCodeBlob(const std::vector<uint8_t>& rom) {
     uint32_t blobRom = 0, firstTarget = 0, ramBase = 0;
     int jalCount = 0;

--- a/src/factories/bk64/ConfigFactory.h
+++ b/src/factories/bk64/ConfigFactory.h
@@ -69,6 +69,12 @@ enum class CustomCodeKind : uint16_t {
     BB_INJECTED = 2,
 };
 
+// Pre-extraction probe for callers that decide the warning policy themselves
+// (e.g. the extraction UI checks RomhackTable for hand-ported hashes): reports
+// the detected blob's kind and its SHA1 as 40 lowercase hex chars + NUL.
+// Returns false (kind NONE, empty hash) when no blob is found.
+bool GetCustomCodeBlobInfo(const std::vector<uint8_t>& rom, CustomCodeKind& outKind, char outSha1Hex[41]);
+
 // CODE_CONSTANTS key IDs - they index into the sBBConfigs table.
 enum class CodeConstantKey : uint16_t {
     NEW_GAME_MAP = 0,


### PR DESCRIPTION
Forgot to link the warning suppression from the imgui side. This forwards the needed info at pre-extract so imgui's Companion instance can act on it properly.