### PR TITLE
Fix three Windows-only defects in OoT extraction

### DIFF
--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -536,7 +536,7 @@ void Companion::ParseCurrentFileConfig(YAML::Node node, std::atomic<size_t>& ass
                 auto externalFile = externalFiles[i];
                 if (externalFile.size() == 0) {
                     this->gCurrentExternalFiles.push_back(
-                        (this->gSourceDirectory / externalFile.as<std::string>()).string());
+                        (this->gSourceDirectory / externalFile.as<std::string>()).generic_string());
                 } else {
                     SPDLOG_INFO("External File size {}", externalFile.size());
                     throw std::runtime_error(
@@ -544,9 +544,10 @@ void Companion::ParseCurrentFileConfig(YAML::Node node, std::atomic<size_t>& ass
                         " - <external_files>\n\ne.g.:\nexternal_files:\n  - actors/actor1.yaml");
                 }
 
-                std::string externalFileName = (this->gSourceDirectory / externalFile.as<std::string>()).string();
-                if (StringHelper::StartsWith(std::filesystem::relative(externalFileName, this->gAssetPath).string(),
-                                             "../")) {
+                std::string externalFileName =
+                    (this->gSourceDirectory / externalFile.as<std::string>()).generic_string();
+                if (StringHelper::StartsWith(
+                        std::filesystem::relative(externalFileName, this->gAssetPath).generic_string(), "../")) {
                     throw std::runtime_error("External File " + externalFileName + " Not In Asset Directory " +
                                              this->gAssetPath);
                 } else if (std::filesystem::relative(externalFileName, this->gAssetPath).string() == "") {

--- a/src/Companion.h
+++ b/src/Companion.h
@@ -248,7 +248,7 @@ public:
     std::optional<std::tuple<std::string, YAML::Node>> RegisterAsset(const std::string& name, YAML::Node& node);
     std::optional<YAML::Node> AddSubFileAsset(YAML::Node asset, std::string newFileName, CompressionType newCompressionType, uint32_t compressedSize = 0);
     std::optional<YAML::Node> AddAsset(YAML::Node asset);
-    std::string GetCurrentDirectory() const { return gCurrentDirectory.string(); }
+    std::string GetCurrentDirectory() const { return gCurrentDirectory.generic_string(); }
     void SetCompressedSegment(uint32_t segmentId, uint32_t compressedFileOffset, uint32_t offset);
     bool GetCompressedSegmentOffset(uint32_t* addr);
 

--- a/src/factories/oot/OoTAudioFactory.cpp
+++ b/src/factories/oot/OoTAudioFactory.cpp
@@ -5,12 +5,23 @@
 #include "spdlog/spdlog.h"
 #include "Companion.h"
 #include "utils/Decompressor.h"
+#include <algorithm>
 #include <sstream>
 
 namespace OoT {
 
-std::vector<AudioTableEntry> OoTAudioFactory::ParseAudioTable(const uint8_t* codeData, uint32_t tableOffset) {
-    LUS::BinaryReader reader((char*)(codeData + tableOffset), 0x10000);
+// BinaryReader copies its whole window up front, so the window must not run past the segment.
+static size_t TableWindow(size_t segmentSize, uint32_t tableOffset) {
+    if (tableOffset >= segmentSize) {
+        throw std::runtime_error("Audio table offset 0x" + fmt::format("{:X}", tableOffset) +
+                                 " is outside the 0x" + fmt::format("{:X}", segmentSize) + " byte code segment");
+    }
+    return std::min<size_t>(segmentSize - tableOffset, 0x10000);
+}
+
+std::vector<AudioTableEntry> OoTAudioFactory::ParseAudioTable(const uint8_t* codeData, size_t segmentSize,
+                                                              uint32_t tableOffset) {
+    LUS::BinaryReader reader((char*)(codeData + tableOffset), TableWindow(segmentSize, tableOffset));
     reader.SetEndianness(Torch::Endianness::Big);
 
     uint16_t numEntries = reader.ReadUInt16();
@@ -36,11 +47,11 @@ std::vector<AudioTableEntry> OoTAudioFactory::ParseAudioTable(const uint8_t* cod
 }
 
 std::vector<std::vector<uint8_t>> OoTAudioFactory::ParseSequenceFontTable(
-    const uint8_t* codeData, uint32_t tableOffset, uint32_t numSequences) {
+    const uint8_t* codeData, size_t segmentSize, uint32_t tableOffset, uint32_t numSequences) {
     std::vector<std::vector<uint8_t>> result;
     result.reserve(numSequences);
 
-    LUS::BinaryReader reader((char*)(codeData + tableOffset), 0x10000);
+    LUS::BinaryReader reader((char*)(codeData + tableOffset), TableWindow(segmentSize, tableOffset));
     reader.SetEndianness(Torch::Endianness::Big);
 
     std::vector<uint16_t> offsets;
@@ -92,10 +103,16 @@ std::optional<std::shared_ptr<IParsedData>> OoTAudioFactory::parse(std::vector<u
         buffer);
 
     // Parse audio tables from code segment at YAML-specified offsets
-    auto seqTable = ParseAudioTable(codeDecoded.segment.data, GetSafeNode<uint32_t>(node, "sequence_table_offset"));
-    auto fontTable = ParseAudioTable(codeDecoded.segment.data, GetSafeNode<uint32_t>(node, "sound_font_table_offset"));
-    auto sampleBankTable = ParseAudioTable(codeDecoded.segment.data, GetSafeNode<uint32_t>(node, "sample_bank_table_offset"));
-    auto seqFontMap = ParseSequenceFontTable(codeDecoded.segment.data, GetSafeNode<uint32_t>(node, "sequence_font_table_offset"), seqTable.size());
+    const size_t codeSize = codeDecoded.segment.size;
+    auto seqTable =
+        ParseAudioTable(codeDecoded.segment.data, codeSize, GetSafeNode<uint32_t>(node, "sequence_table_offset"));
+    auto fontTable =
+        ParseAudioTable(codeDecoded.segment.data, codeSize, GetSafeNode<uint32_t>(node, "sound_font_table_offset"));
+    auto sampleBankTable =
+        ParseAudioTable(codeDecoded.segment.data, codeSize, GetSafeNode<uint32_t>(node, "sample_bank_table_offset"));
+    auto seqFontMap = ParseSequenceFontTable(codeDecoded.segment.data, codeSize,
+                                             GetSafeNode<uint32_t>(node, "sequence_font_table_offset"),
+                                             seqTable.size());
 
     SPDLOG_INFO("OoTAudioFactory: {} sequences, {} fonts, {} sample banks",
                 seqTable.size(), fontTable.size(), sampleBankTable.size());

--- a/src/factories/oot/OoTAudioFactory.h
+++ b/src/factories/oot/OoTAudioFactory.h
@@ -26,8 +26,8 @@ public:
 private:
     std::vector<char> BuildMainAudioHeader();
     std::optional<SafeAudioBankReader> LoadAudioBank(std::vector<uint8_t>& buffer);
-    std::vector<AudioTableEntry> ParseAudioTable(const uint8_t* codeData, uint32_t tableOffset);
-    std::vector<std::vector<uint8_t>> ParseSequenceFontTable(const uint8_t* codeData,
+    std::vector<AudioTableEntry> ParseAudioTable(const uint8_t* codeData, size_t segmentSize, uint32_t tableOffset);
+    std::vector<std::vector<uint8_t>> ParseSequenceFontTable(const uint8_t* codeData, size_t segmentSize,
                                                               uint32_t tableOffset, uint32_t numSequences);
 };
 


### PR DESCRIPTION
Three defects in the OoT factories that only manifest on Windows, found while integrating Torch into Ship of Harkinian as its asset pipeline ([Shipwright#6989](https://github.com/HarbourMasters/Shipwright/pull/6989)). Two are hard crashes; the third silently doubles the work and the archive.

All three are separator or bounds mistakes that are invisible on Linux and macOS, which is why OoT support looked fine — every extraction there produces identical output before and after this PR.

## 1. `ParseAudioTable` reads 64 KiB regardless of what is left in the segment

`OoTAudioFactory.cpp:13` and `:43` each built a `BinaryReader` over a fixed `0x10000` window at the table offset. `MemoryStream`'s constructor copies the whole window up front, so the copy runs off the end of the decoded code segment when a table sits near it.

For PAL GC the sample bank table is at `0x1000B0` in a segment of `0x102250` bytes — 8,608 bytes available, 65,536 requested, **56,928 bytes over the end**. glibc leaves those pages mapped so it goes unnoticed; on Windows the following page is often unmapped and it is an access violation that kills extraction:

```
memcpy_repmovs
LUS::MemoryStream::MemoryStream        lib/binarytools/MemoryStream.cpp:16
LUS::BinaryReader::BinaryReader        lib/binarytools/BinaryReader.cpp:8
OoT::OoTAudioFactory::ParseAudioTable  src/factories/oot/OoTAudioFactory.cpp:13
OoT::OoTAudioFactory::parse            src/factories/oot/OoTAudioFactory.cpp:95
Companion::ParseNode                   src/Companion.cpp:493
```

Reproducible on Linux under valgrind, which reports the first bad address as `0 bytes after a block of size 1,057,360`.

Fixed by clamping each window to what remains in the segment. `parse()` already had `codeDecoded.segment.size` in hand.

## 2. Scene resource names carry backslashes

`Companion::GetCurrentDirectory()` returned `gCurrentDirectory.string()`, so on Windows the scene writer embedded native separators in exported resource names. Archive paths are always forward slash, so the game asks for a name that cannot exist:

```
scenes\nonmq\HIDAN_scene/HIDAN_scenePathwayList_0004AC6   what the scene asks for
scenes/nonmq/HIDAN_scene/HIDAN_scenePathwayList_0004AC6   what the archive contains
```

The lookup returns null and the consumer dereferences it. Rooms are mangled further, because `WriteSetRoomList` derives the base name with `rfind('/')` — which finds nothing in a backslash path, leaving the entire directory in `sceneBase` so it gets concatenated twice:

```
scenes\nonmq\bdan_scene/scenes\nonmq\bdan_room_0          Windows
scenes/nonmq/bdan_scene/bdan_room_0                       Linux
```

101 scene entries differed between platforms because of this.

`GetCurrentDirectory` was added in 4cae441 alongside the scene writer and has exactly one caller, so returning `generic_string()` affects nothing else.

## 3. `external_files` dependencies are keyed differently from the directory walk

The directory walk sets `gCurrentFile` from `entry.path().generic_string()` (`Companion.cpp:1645`); `external_files` built theirs with `.string()` (`:547`). On Windows those are two different strings for one file, so `gProcessedFiles` never matched and every file pulled in as a dependency was processed a second time:

| | Windows before | Windows after | Linux |
| --- | --- | --- | --- |
| phase callbacks for 1450 ymls | 2025 | 1450 | 1450 |
| archive entries | 42,119 | 35,411 | 35,411 |

`gAddrMap` is keyed the same way, so its lookups missed too — that is the source of the `External File {} Not Found` warnings.

The same commit fixes the `"../"` escape guard a few lines up, which compared against `relative(...).string()`. That is `..\` on Windows, so the guard never fired there.

These strings are only ever used as `gAddrMap` keys, as a path for `LoadFile`, and in error text, and outside Windows `generic_string` and `string` return the same value.

## Verification

Extractions of a PAL GC rom, compared entry by entry by CRC:

- **Linux output is unchanged by all three commits** — 35,411 entries, identical CRCs, checked after each one.
- **valgrind**: 8 invalid-read contexts before, 0 after, no `OoTAudioFactory` frames remaining.
- **Windows now matches Linux exactly** — 35,411 entries, 33,154,599 bytes, every CRC identical. Before this PR it crashed mid-extraction; with only the first fix it completed but produced 42,119 entries with 101 differing scenes and crashed at scene load.

Happy to split this into three PRs if you would rather review them separately.
