### PR TITLE
Bump yaml-cpp to 0.9.0 (3.5x faster extraction on Windows)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,7 +339,7 @@ set(YAML_CPP_DISABLE_UNINSTALL ON)
 FetchContent_Declare(
     yaml-cpp
     GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-    GIT_TAG 2f86d13775d119edbb69af52e5f566fd65c6953b
+    GIT_TAG yaml-cpp-0.9.0
 )
 set(YAML_CPP_BUILD_TESTS OFF)
 FetchContent_MakeAvailable(yaml-cpp)


### PR DESCRIPTION
Bumps the yaml-cpp pin from `2f86d13` (2025-03-24) to the **0.9.0 release tag**, which makes an OoT extraction on Windows about **3.5x faster** with byte-identical output.

The pinned commit predates jbeder/yaml-cpp@4fe2fb8 (2025-09-15, first released in 0.9.0), which changed the scalar conversion macro in `include/yaml-cpp/node/convert.h`:

```diff
-      stream.imbue(std::locale("C"));
+      stream.imbue(std::locale::classic());
```

`std::locale("C")` constructs a **named** locale on every conversion. glibc hands back a cached classic locale for nearly nothing, so this is invisible on Linux and macOS. MSVC rebuilds the locale facets through `GetLocaleInfoEx` each time. An OoT extraction performs over a million scalar conversions — 478,124 `offset:` values alone — so it pays that cost a million times.

A Windows CPU profile of an extraction, before the bump:

| function | exclusive |
| --- | --- |
| `kernelbase!GetLocaleInfoEx` | 6.0% |
| `kernelbase!GetLocaleInfoHelper` | 4.8% |
| `soh!wcscat_s` | 3.9% |
| `soh!_W_Gettnames` | 3.3% |
| `kernelbase!LCMapStringEx` | 1.6% |
| `soh!_Mbrtowc` | 1.5% |
| `soh!__acrt_GetLocaleInfoA`, `soh!InternalGetLocaleInfoA`, `soh!std::_Maklocstr` x2 | 2.7% |
| `kernelbase!WideCharToMultiByte`, `GetStringTypeW`, `ntdll!RtlUnicodeToUTF8N`, `RtlUTF8ToUnicodeN` | 2.4% |

That is ~26% in locale construction alone, and each conversion also built a `std::stringstream`, which accounts for a good share of the further 21% spent in `RtlpLowFragHeapAllocFromContext` / `RtlpFreeHeapInternal`.

## Measurements

Ten consecutive in-game extractions of the same PAL GC rom, on one Windows machine, all Release builds. ZAPDTR is included as a reference point because it is what the Ship of Harkinian port used before Torch.

Each column is a Ship of Harkinian branch whose rom picker runs ten extractions back to back and appends each run's wall clock to a csv. The branches are identical apart from the pipeline under test:

| column | branch | torch pin |
| --- | --- | --- |
| ZAPDTR | `benchmark-extraction-zapd` ([`57400be`](https://github.com/HarbourMasters/Shipwright/commit/57400beb8eec60929596e199e92b46cf5b0e712a)) | n/a, off `develop` |
| Torch, yaml-cpp `2f86d13` | `benchmark-extraction-torch` ([`3fe654b`](https://github.com/HarbourMasters/Shipwright/commit/3fe654b374341a2a2374361ed727eb161eacc673)) | [`b10d71d`](https://github.com/HarbourMasters/Torch/commit/b10d71da3712cd71e159caaf1bbf305385101870) |
| Torch, yaml-cpp 0.9.0 | `benchmark-extraction-torch-yamlcpp` ([`01ddd62`](https://github.com/HarbourMasters/Shipwright/commit/01ddd62609c67585cc2a3ad8520494307bbad1f2)) | [`869dc34`](https://github.com/HarbourMasters/Torch/commit/869dc3448760f0a794dfd9a35eb62a5bbcef7167) |

`b10d71d` is tree-identical to upstream `65eb11c`, and `869dc34` is `65eb11c` plus this one-line commit, so yaml-cpp is the only difference between the two Torch columns.

| run | ZAPDTR | Torch, yaml-cpp `2f86d13` | Torch, yaml-cpp 0.9.0 |
| ---: | ---: | ---: | ---: |
| 1 | 52.055 | 54.227 | **18.850** |
| 2 | 50.096 | 47.656 | **13.218** |
| 3 | 49.890 | 47.473 | **13.488** |
| 4 | 49.065 | 49.086 | **13.558** |
| 5 | 48.909 | 49.357 | **13.738** |
| 6 | 47.647 | 48.625 | **14.052** |
| 7 | 47.697 | 49.985 | **14.187** |
| 8 | 47.600 | 49.564 | **14.162** |
| 9 | 47.442 | 49.841 | **14.345** |
| 10 | 47.562 | 49.405 | **14.604** |
| **mean, runs 2-10** | **48.434** | **48.999** | **13.928** |

Run 1 is warm-up in every column, so the means exclude it — but the improvement holds there too, 54.227 to 18.850.

Before the bump Torch was fractionally behind ZAPDTR on this machine; after it, Torch is 3.5x ahead of both.

**Nothing changes on Linux**, as expected given the mechanism: the same extraction measured 4.16 / 4.14 / 4.17 seconds before and 4.13 / 4.15 / 4.14 after.

## Output is unchanged

Every archive produced above was compared entry by entry by CRC:

- Windows before the bump vs Windows after: **35,386 entries, all CRCs identical**
- Windows after vs a Linux extraction of the same rom: **identical**

The 0.9.0 release also builds clean with no source changes needed, despite roughly sixteen months of drift from the pinned commit.
