### PR TITLE
Pin libultraship to a specific commit instead of tracking main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ if(BUILD_UI)
     FetchContent_Declare(
         libultraship
         GIT_REPOSITORY https://github.com/Kenix3/libultraship.git
-        GIT_TAG main
+        GIT_TAG a3f1e102e1ed50a3f536fbca2e6e412170e7320b
     )
     FetchContent_MakeAvailable(libultraship)
 


### PR DESCRIPTION
## Problem

CI on `main` went red after #237, which only touched `Companion.cpp`, `Companion.h`, and `main.cpp`. The failure was unrelated to that change:

```
src/ui/backends/LusBackend.cpp:12:10: fatal error: ship/Context.h: No such file or directory
```

`CMakeLists.txt` declared libultraship with `GIT_TAG main`, so every push refetched whatever upstream happened to be at that moment. Upstream had been quiet since June 13, then landed five commits on July 29–30 — notably [Separates Ship and Fast/LUS namespaces (#1177)](https://github.com/Kenix3/libultraship/pull/1177) and [Component system (#1174)](https://github.com/Kenix3/libultraship/pull/1174). #1177 moved `Context.h` to `include/ship/core/Context.h`. The next Torch push picked it up and broke.

Only the `BUILD_UI=ON` legs actually fail; the matrix is fail-fast, so the other seven jobs report "canceled" rather than independent failures.

## Fix

Pin to `a3f1e102`, which was the tip of upstream `main` during the last green run (#236, July 26). LUS bumps become deliberate instead of a side effect of unrelated pushes.

## Verification

Built the exact failing matrix leg locally — Debug, `USE_STANDALONE=ON`, `BUILD_UI=ON`, `linux-gnu`:

- Configure clean, build exit 0, 428/428 targets, `torch` linked
- `LusBackend.cpp.o` — the file CI choked on — compiles
- Zero `error:` lines; warnings match those in the last green run
- Fetched tree confirms `HEAD` = `a3f1e102e1ed50a3f536fbca2e6e412170e7320b`, with `Context.h` at `include/ship/Context.h`, resolving via the existing `${libultraship_SOURCE_DIR}/include` entry

## Note for reviewers

The pin is ~7 weeks behind upstream, and the gap contains the namespace split and component system. Whoever bumps it will need to port `LusBackend.cpp` across both — worth doing as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)