### PR TITLE
Run build workflows on PRs targeting main

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "*" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/mac_build.yml
+++ b/.github/workflows/mac_build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "*" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "*" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
## Problem

`linux_build.yml`, `mac_build.yml`, and `windows_build.yml` all gate their `pull_request` trigger on `master`:

```yaml
on:
  push:
    branches: [ "*" ]
  pull_request:
    branches: [ "master" ]
```

The default branch is `main`, so PRs don't currently trigger these workflows. Only the `push` trigger fires, which means a broken build surfaces after a merge to `main` rather than on the PR that introduces it.

`doc.yml` and `release.yml` already reference `main` correctly.

## Fix

`master` → `main` in the three build workflows. No other changes.

## Verification

For `pull_request` events GitHub evaluates the workflow file from the PR merge ref, so this PR should trigger the three build workflows itself — that's the check on whether it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)