### PR TITLE
Use our own vcpkg root on Windows instead of the runner's

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -28,13 +28,21 @@ jobs:
             standalone: OFF
     steps:
       - uses: actions/checkout@v4
+      - name: Cache vcpkg
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-vcpkg-x64-windows-static-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-x64-windows-static-
+          path: D:/a/vcpkg
       - name: Build Visual Studio
         if: ${{ matrix.generate == 'Visual Studio 17 2022' }}
+        env:
+          VCPKG_ROOT: D:/a/vcpkg
         run: |
           # Enable the viewer in CI (BUILD_UI is off by default), except on Win32:
-          # libultraship is x64-only. Its automate-vcpkg bootstraps the runner's
-          # vcpkg to fetch SDL2/GLEW/libzip/nlohmann-json/tinyxml2/spdlog.
-          $env:VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT
+          # libultraship is x64-only. Its automate-vcpkg bootstraps vcpkg to
+          # fetch SDL2/GLEW/libzip/nlohmann-json/tinyxml2/spdlog.
           cmake -S . -B "build/${{ matrix.arch }}" -G "${{ matrix.generate }}" -DCMAKE_TOOLCHAIN_FILE="cmake/toolchain/${{ matrix.toolchain }}.cmake" -DCMAKE_GENERATOR_PLATFORM=${{ matrix.arch }} -DCMAKE_BUILD_TYPE:STRING=${{ matrix.config }} -DUSE_STANDALONE=${{ matrix.standalone }} -DBUILD_UI=${{ matrix.arch == 'Win32' && 'OFF' || 'ON' }} -DUSE_AUTO_VCPKG=ON -DVCPKG_TARGET_TRIPLET=x64-windows-static
           # Multi-config generator: pass --config, else it builds Debug and the
           # Release artifact path below finds nothing.
@@ -46,11 +54,12 @@ jobs:
           arch: ${{ matrix.arch }}
       - name: Build Ninja
         if: ${{ matrix.generate == 'Ninja' }}
+        env:
+          VCPKG_ROOT: D:/a/vcpkg
         run: |
           # Enable the viewer in CI, off on Win32 (libultraship is x64-only). Ninja
           # is single-platform, so name the vcpkg triplet explicitly (there is no
           # CMAKE_VS_PLATFORM_NAME for automate-vcpkg to key off).
-          $env:VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT
           cmake -S . -B "build/${{ matrix.arch }}" -G "${{ matrix.generate }}" -DCMAKE_TOOLCHAIN_FILE="cmake/toolchain/${{ matrix.toolchain }}.cmake" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.config }} -DUSE_STANDALONE=${{ matrix.standalone }} -DBUILD_UI=${{ matrix.arch == 'Win32' && 'OFF' || 'ON' }} -DUSE_AUTO_VCPKG=ON -DVCPKG_TARGET_TRIPLET=x64-windows-static
           cmake --build ./build/${{ matrix.arch }}
       - name: Publish packaged artifacts


### PR DESCRIPTION
## Problem

Every Windows **x64** job has been failing since earlier today, on `main` as well as on PRs — including [the push run for #238](https://github.com/HarbourMasters/Torch/actions/runs/30563153450), which is otherwise green on Linux and macOS. This is a separate breakage from the libultraship one #238 fixed:

```
C:\vcpkg\scripts\vcpkg-tools.json: error: $ (a tool data file):
document schema version 2 is not supported by this version of vcpkg
→ CMake Error at C:/vcpkg/scripts/buildsystems/vcpkg.cmake:939 (_find_package):
    Could not find a package configuration file provided by "SDL2"
```

Both build steps did:

```powershell
$env:VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT
```

`VCPKG_INSTALLATION_ROOT` is the vcpkg preinstalled in the runner image (`C:\vcpkg`). `automate-vcpkg` updates the ports tree in place, and that tree now ships a schema-v2 `vcpkg-tools.json` the image's older `vcpkg.exe` can't read. No packages install, so `find_package(SDL2)` fails and the job dies during configure.

Win32 is unaffected: it builds with `BUILD_UI=OFF` and never asks vcpkg for anything. That's why only the x64 legs went red.

Nothing in Torch changed to cause this — it's drift between the runner image's vcpkg and the ports tree.

## Fix

Point `VCPKG_ROOT` at an empty `D:/a/vcpkg` so `automate-vcpkg` clones and bootstraps the tool alongside the ports tree it will use, keeping the two on one revision. This mirrors what the ports and libultraship already do — Torch was the odd one out in reusing the runner's vcpkg.

It is set as step-level `env:` rather than on the job, because `msvc-dev-cmd` runs before the Ninja build step and exports its own `VCPKG_ROOT` pointing at the vcpkg bundled with Visual Studio, which is not a git checkout. Step-level env takes precedence over that. libultraship's `build-validation.yml` sets it the same way.

A fresh root builds dependencies from source, so the branch also adds an `actions/cache` entry for it to keep run times close to what the preinstalled vcpkg gave us.

## Verification

Branch run: https://github.com/briaguya0/Torch/actions/runs/30567589282

Note that CI does not run on PRs until #239 lands, so the branch run above is the signal here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)