### PR TITLE
Make O2R packing deterministic and contained

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -35,6 +35,12 @@ jobs:
           # toolchains build the GL backend.
           cmake -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DUSE_STANDALONE=${{ matrix.standalone }} -DBUILD_UI=ON -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain/${{ matrix.toolchain }}.cmake
           cmake --build build-cmake -j
+      - name: Validate deterministic standalone archives
+        if: ${{ matrix.config == 'Release' && matrix.standalone == 'ON' && matrix.toolchain == 'linux-gnu' }}
+        run: |
+          python3 test/pack/validate_deterministic_o2r.py \
+            --torch build-cmake/torch \
+            --work-dir "$RUNNER_TEMP/torch-deterministic-pack"
       - name: Create Package
         if: ${{ matrix.config == 'Release' && matrix.standalone == 'ON' && matrix.toolchain == 'linux-gnu' }}
         run: |

--- a/.github/workflows/mac_build.yml
+++ b/.github/workflows/mac_build.yml
@@ -43,6 +43,12 @@ jobs:
           # toolchain: the Metal backend needs clang/Objective-C++.
           cmake -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DUSE_STANDALONE=${{ matrix.standalone }} -DBUILD_UI=${{ matrix.toolchain == 'macos-gnu' && 'OFF' || 'ON' }} -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain/${{ matrix.toolchain }}.cmake
           cmake --build build-cmake -j
+      - name: Validate deterministic standalone archives
+        if: ${{ matrix.config == 'Release' && matrix.standalone == 'ON' && matrix.toolchain == 'macos-clang' }}
+        run: |
+          python3 test/pack/validate_deterministic_o2r.py \
+            --torch build-cmake/torch \
+            --work-dir "$RUNNER_TEMP/torch-deterministic-pack"
       - name: Create Package
         if: ${{ matrix.config == 'Release' && matrix.standalone == 'ON' && matrix.toolchain == 'macos-clang' }}
         run: |

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -62,6 +62,13 @@ jobs:
           # CMAKE_VS_PLATFORM_NAME for automate-vcpkg to key off).
           cmake -S . -B "build/${{ matrix.arch }}" -G "${{ matrix.generate }}" -DCMAKE_TOOLCHAIN_FILE="cmake/toolchain/${{ matrix.toolchain }}.cmake" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.config }} -DUSE_STANDALONE=${{ matrix.standalone }} -DBUILD_UI=${{ matrix.arch == 'Win32' && 'OFF' || 'ON' }} -DUSE_AUTO_VCPKG=ON -DVCPKG_TARGET_TRIPLET=x64-windows-static
           cmake --build ./build/${{ matrix.arch }}
+      - name: Validate deterministic standalone archives
+        if: ${{ matrix.config == 'Release' && matrix.generate == 'Visual Studio 17 2022' && matrix.standalone == 'ON' && matrix.toolchain == 'windows-msvc' && matrix.arch == 'x64' }}
+        shell: pwsh
+        run: |
+          python test/pack/validate_deterministic_o2r.py `
+            --torch build/x64/Release/torch.exe `
+            --work-dir "${{ runner.temp }}/torch-deterministic-pack"
       - name: Publish packaged artifacts
         if: ${{ matrix.config == 'Release' && matrix.generate == 'Visual Studio 17 2022' && matrix.standalone == 'ON' }}
         uses: actions/upload-artifact@v4

--- a/lib/miniz/zip_file.hpp
+++ b/lib/miniz/zip_file.hpp
@@ -4344,6 +4344,9 @@ mz_bool mz_zip_writer_add_mem_ex(mz_zip_archive *pZip, const char *pArchive_name
     time_t cur_time; time(&cur_time);
     mz_zip_time_to_dos_time(cur_time, &dos_time, &dos_date);
   }
+#else
+  /* DOS epoch: 1980-01-01 00:00:00. */
+  dos_date = (1U << 5U) | 1U;
 #endif // #ifndef MINIZ_NO_TIME
 
   archive_name_size = strlen(pArchive_name);
@@ -5702,6 +5705,7 @@ private:
         result.file_size = static_cast<std::size_t>(stat.m_uncomp_size);
         result.header_offset = static_cast<std::size_t>(stat.m_local_header_ofs);
         result.crc = stat.m_crc32;
+#ifndef MINIZ_NO_TIME
         auto time = detail::safe_localtime(stat.m_time);
         result.date_time.year = 1900 + time.tm_year;
         result.date_time.month = 1 + time.tm_mon;
@@ -5709,6 +5713,14 @@ private:
         result.date_time.hours = time.tm_hour;
         result.date_time.minutes = time.tm_min;
         result.date_time.seconds = time.tm_sec;
+#else
+        result.date_time.year = 1980;
+        result.date_time.month = 1;
+        result.date_time.day = 1;
+        result.date_time.hours = 0;
+        result.date_time.minutes = 0;
+        result.date_time.seconds = 0;
+#endif
         result.flag_bits = stat.m_bit_flag;
         result.internal_attr = stat.m_internal_attr;
         result.external_attr = stat.m_external_attr;

--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -9,12 +9,14 @@
 #include "spdlog/spdlog.h"
 #include "TinySHA1.hpp"
 
+#include <algorithm>
 #include <regex>
 #include <fstream>
 #include <iostream>
 #include <filesystem>
 #include <thread>
 #include <mutex>
+#include <map>
 
 #include "factories/GenericArrayFactory.h"
 #include "factories/VtxFactory.h"
@@ -1842,17 +1844,37 @@ void Companion::Pack(const std::string& folder, const std::string& output, const
     SPDLOG_CRITICAL("Scanning {}", folder);
 
     auto start = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
-    std::unordered_map<std::string, std::vector<char>> files;
+    std::map<std::string, std::vector<char>> files;
+    const auto rootPath = fs::path(folder).lexically_normal();
+    const auto canonicalRootPath = fs::canonical(rootPath);
+    const auto isContainedRelativePath = [](const fs::path& path) {
+        return !path.empty() && !path.is_absolute() && !path.has_root_path() &&
+               std::none_of(path.begin(), path.end(), [](const auto& component) { return component == ".."; });
+    };
+    const auto canonicalOutputPath = fs::weakly_canonical(fs::absolute(fs::path(output)));
+    const auto outputRelativePath = canonicalOutputPath.lexically_relative(canonicalRootPath);
+    if (isContainedRelativePath(outputRelativePath)) {
+        throw std::runtime_error("Output archive must be outside the selected input directory: " + output);
+    }
 
     for (const auto& entry : Torch::getRecursiveEntries(folder)) {
         if (entry.is_directory()) {
             continue;
         }
 
+        const auto archivePath = entry.path().lexically_normal().lexically_relative(rootPath);
+        const auto targetPath = fs::canonical(entry.path()).lexically_relative(canonicalRootPath);
+        if (!isContainedRelativePath(archivePath) || !isContainedRelativePath(targetPath)) {
+            throw std::runtime_error("Packed file is outside the selected input directory: " + entry.path().string());
+        }
+
         std::ifstream input(entry.path(), std::ios::binary);
+        if (!input) {
+            throw std::runtime_error("Could not open packed file: " + entry.path().string());
+        }
         auto data = std::vector(std::istreambuf_iterator(input), {});
         input.close();
-        files[entry.path().generic_string()] = data;
+        files[archivePath.generic_string()] = data;
     }
 
     std::unique_ptr<BinaryWrapper> wrapper;
@@ -1869,12 +1891,8 @@ void Companion::Pack(const std::string& folder, const std::string& output, const
     wrapper->CreateArchive();
 
     for (auto& [path, data] : files) {
-        std::string normalized = path;
-        std::replace(normalized.begin(), normalized.end(), '\\', '/');
-        // Remove parent folder
-        normalized = normalized.substr(folder.length() + 1);
-        wrapper->AddFile(normalized, data);
-        SPDLOG_CRITICAL("> Added {}", normalized);
+        wrapper->AddFile(path, data);
+        SPDLOG_CRITICAL("> Added {}", path);
     }
 
     if (!version.empty()) {

--- a/src/archive/ZWrapper.cpp
+++ b/src/archive/ZWrapper.cpp
@@ -5,6 +5,7 @@
 
 #include "spdlog/spdlog.h"
 #include <Companion.h>
+#define MINIZ_NO_TIME
 #include <miniz/zip_file.hpp>
 
 namespace fs = std::filesystem;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <exception>
 #include <memory>
 #include <algorithm>
 #include <atomic>
@@ -448,6 +449,12 @@ int main(int argc, char* argv[]) {
     } catch (const CLI::ParseError& e) {
         std::cout << app.help() << std::endl;
         return app.exit(e);
+    } catch (const std::exception& e) {
+        std::cerr << "Torch failed: " << e.what() << std::endl;
+        return 1;
+    } catch (...) {
+        std::cerr << "Torch failed: unknown exception" << std::endl;
+        return 1;
     }
 
     // No arguments --> display help.

--- a/test/pack/validate_deterministic_o2r.py
+++ b/test/pack/validate_deterministic_o2r.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Validate deterministic, root-relative O2R packing without game data."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import subprocess
+import sys
+import zipfile
+
+
+BASE_ENTRIES = ["alpha.txt", "nested/beta.bin", "nested/deeper/gamma.txt"]
+
+
+def run_torch(torch: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(torch), *arguments],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def pack(torch: Path, source: Path, output: Path) -> None:
+    result = run_torch(torch, "pack", str(source), str(output), "o2r")
+    require(
+        result.returncode == 0,
+        f"Torch pack failed with exit {result.returncode}:\n{result.stdout}\n{result.stderr}",
+    )
+    require(output.is_file(), f"Torch did not create {output}")
+
+
+def validate_archive(path: Path, expected_entries: list[str]) -> None:
+    with zipfile.ZipFile(path, "r") as archive:
+        infos = archive.infolist()
+        names = [info.filename for info in infos]
+        require(names == expected_entries, f"unexpected archive order or paths: {names}")
+        require(all(not Path(name).is_absolute() for name in names), "archive contains an absolute path")
+        require(all(".." not in Path(name).parts for name in names), "archive contains a parent traversal")
+        timestamps = {info.date_time for info in infos}
+        require(len(timestamps) == 1, f"archive timestamps are not fixed: {sorted(timestamps)}")
+        timestamp = next(iter(timestamps))
+        require(timestamp == (1980, 1, 1, 0, 0, 0), f"unexpected fixed timestamp: {timestamp}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--torch", required=True, type=Path)
+    parser.add_argument("--work-dir", required=True, type=Path)
+    args = parser.parse_args()
+
+    torch = args.torch.resolve()
+    work_dir = args.work_dir.resolve()
+    require(torch.is_file(), f"Torch executable is missing: {torch}")
+
+    require(not work_dir.exists(), f"--work-dir must not already exist: {work_dir}")
+    source = work_dir / "source"
+    (source / "nested" / "deeper").mkdir(parents=True)
+
+    # Deliberately create entries out of lexical order.
+    (source / "nested" / "deeper" / "gamma.txt").write_text("gamma\n", encoding="utf-8")
+    (source / "alpha.txt").write_text("alpha\n", encoding="utf-8")
+    (source / "nested" / "beta.bin").write_bytes(bytes(range(64)))
+
+    inside = source / "inside.o2r"
+    contained = run_torch(torch, "pack", str(source), str(inside), "o2r")
+    contained_output = contained.stdout + contained.stderr
+    require(contained.returncode == 1, "output inside the input tree was accepted")
+    require(
+        "Output archive must be outside the selected input directory" in contained_output,
+        "contained output error was not reported cleanly",
+    )
+    require(not inside.exists(), "contained output archive was created")
+
+    first = work_dir / "first.o2r"
+    second = work_dir / "second.o2r"
+    pack(torch, source, first)
+    validate_archive(first, BASE_ENTRIES)
+
+    for index, path in enumerate(source.rglob("*")):
+        if path.is_file():
+            timestamp = 1_700_000_000 + (index * 60)
+            os.utime(path, (timestamp, timestamp))
+
+    pack(torch, source, second)
+    validate_archive(second, BASE_ENTRIES)
+    require(first.read_bytes() == second.read_bytes(), "archives differ after source mtime changes")
+
+    invalid = run_torch(torch, "pack", str(source), str(work_dir / "invalid.bin"), "invalid")
+    combined_output = invalid.stdout + invalid.stderr
+    require(invalid.returncode == 1, f"invalid archive type returned {invalid.returncode}")
+    require("Torch failed:" in combined_output, "invalid archive error was not reported cleanly")
+
+    outside = work_dir / "outside.txt"
+    outside.write_text("outside symlink target\n", encoding="utf-8")
+    symlink = source / "nested" / "outside-link.txt"
+    try:
+        symlink.symlink_to(outside)
+    except OSError:
+        pass
+    else:
+        escaped = run_torch(torch, "pack", str(source), str(work_dir / "escaped.o2r"), "o2r")
+        escaped_output = escaped.stdout + escaped.stderr
+        require(escaped.returncode == 1, f"outside symlink returned {escaped.returncode}")
+        require("outside the selected input directory" in escaped_output, "outside symlink was not rejected cleanly")
+
+    print(f"deterministic O2R SHA256: {sha256(first)}")
+    print("entries: " + ", ".join(BASE_ENTRIES))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as error:
+        print(f"validation failed: {error}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary

- write standalone O2R entries in stable root-relative order with valid fixed ZIP timestamps
- reject symlink escapes and output archives resolved inside their own input tree
- report pack failures cleanly and run one source-free determinism check per hosted platform

## Testing

- configured and built the full standalone MSVC x64 Release target with `BUILD_UI=OFF`
- ran `test/pack/validate_deterministic_o2r.py` against the built executable (SHA-256 `5e4452e3a189491044bf36ffadb0f235a49828f38bd6c15ac49e8bd92d1ad266`)
- verified stable bytes after mtime changes, sorted root-relative entries, DOS-epoch timestamps, contained-output refusal, symlink escape rejection, invalid-type diagnostics, and preservation of an existing validation directory
- passed clang-format 14 dry-run, workflow YAML parsing, and `git diff --check`