### PR TITLE
BK: asan, dialog, and romhack edits

### DIFF
--- a/lib/n64graphics/n64graphics.c
+++ b/lib/n64graphics/n64graphics.c
@@ -209,12 +209,14 @@ uint8_t* ci2raw(const uint8_t* rawci, const uint8_t* palette, int width, int hei
     }
 
     for (int i = 0; i < width * height; i++) {
-        int pal_idx = rawci[i];
+        int pal_idx;
         if (ci_depth == 4) {
             int byte_idx = i / 2;
             int nibble = 1 - (i % 2);
             int shift = 4 * nibble;
             pal_idx = (rawci[byte_idx] >> shift) & 0xF;
+        } else {
+            pal_idx = rawci[i];
         }
         raw[2 * i] = palette[2 * pal_idx];
         raw[2 * i + 1] = palette[2 * pal_idx + 1];
@@ -825,7 +827,7 @@ int convert_raw_to_ci8(unsigned char **png_output, int *size_output, uint8_t *te
     uint8_t *raw_fmt;
     rgba *imgr;
     ia   *imgi;
-    int res;
+    int res = 0;
 
     raw_fmt = ci2raw(texture, palette, width, height, depth);
     switch (format) {
@@ -843,7 +845,9 @@ int convert_raw_to_ci8(unsigned char **png_output, int *size_output, uint8_t *te
             break;
         default:
             //ERROR("Unsupported palette format: %s\n", format2str(&config.pal_format));
+            free(raw_fmt);
             return EXIT_FAILURE;
     }
     free(raw_fmt);
+    return res;
 }

--- a/src/factories/bk64/BKAssetFactory.cpp
+++ b/src/factories/bk64/BKAssetFactory.cpp
@@ -4,6 +4,7 @@
 #include "spdlog/spdlog.h"
 #include "utils/Decompressor.h"
 #include "TinySHA1.hpp"
+#include <algorithm>
 #include <cstring>
 #include <iomanip>
 #include <thread>
@@ -305,6 +306,34 @@ std::optional<std::shared_ptr<IParsedData>> BKAssetFactory::parse(std::vector<ui
 
     int count = 0;
 
+    // Slot size = gap to the next-higher table offset.
+    std::vector<uint32_t> sortedOffsets;
+    sortedOffsets.reserve(assetTableInfo.size());
+    for (const auto& ai : assetTableInfo) {
+        sortedOffsets.push_back(ai.offset);
+    }
+    std::sort(sortedOffsets.begin(), sortedOffsets.end());
+    sortedOffsets.erase(std::unique(sortedOffsets.begin(), sortedOffsets.end()), sortedOffsets.end());
+    auto slotSize = [&](uint32_t off) -> uint32_t {
+        auto it = std::upper_bound(sortedOffsets.begin(), sortedOffsets.end(), off);
+        if (it != sortedOffsets.end()) {
+            return *it - off;
+        }
+        uint64_t start = static_cast<uint64_t>(dataStartRomOffset) + off;
+        return start < buffer.size() ? static_cast<uint32_t>(buffer.size() - start) : 0;
+    };
+
+    size_t outOfOrder = 0;
+    for (uint32_t i = 0; i + 1 < assetCount; i++) {
+        if (assetTableInfo.at(i + 1).offset < assetTableInfo.at(i).offset) {
+            outOfOrder++;
+        }
+    }
+    if (outOfOrder > 0) {
+        SPDLOG_WARN("Asset table is not monotonic ({} out-of-order entries); sizing slots by next-higher offset",
+                    outOfOrder);
+    }
+
     // Warm the decompressor cache up front, in parallel. The serial parse
     // pass below then mostly hits already-decoded data.
     struct DecompJob {
@@ -316,18 +345,10 @@ std::optional<std::shared_ptr<IParsedData>> BKAssetFactory::parse(std::vector<ui
         auto& ai = assetTableInfo.at(i);
         if (ai.tFlag == 4 || ai.compressionFlag == 0)
             continue;
-        uint32_t sz = assetTableInfo.at(i + 1).offset - ai.offset;
-        if (sz == 0) {
-            for (uint32_t j = i + 2; j < assetCount; j++) {
-                if (assetTableInfo.at(j).offset != ai.offset) {
-                    sz = assetTableInfo.at(j).offset - ai.offset;
-                    break;
-                }
-            }
-        }
-        uint32_t off = dataStartRomOffset + ai.offset;
-        if (off + sz <= buffer.size()) {
-            decompJobs.push_back({ off, sz });
+        uint32_t sz = slotSize(ai.offset);
+        uint64_t off = static_cast<uint64_t>(dataStartRomOffset) + ai.offset;
+        if (sz > 0 && off + sz <= buffer.size()) {
+            decompJobs.push_back({ static_cast<uint32_t>(off), sz });
         }
     }
 
@@ -363,19 +384,7 @@ std::optional<std::shared_ptr<IParsedData>> BKAssetFactory::parse(std::vector<ui
         try {
             auto assetInfo = assetTableInfo.at(i);
 
-            // Size is the gap to the next asset's offset.
-            uint32_t assetSize = assetTableInfo.at(i + 1).offset - assetInfo.offset;
-
-            // Same offset means an empty slot sits in between; skip ahead until the
-            // offset actually changes to find the real boundary.
-            if (assetSize == 0) {
-                for (uint32_t j = i + 2; j < assetCount; j++) {
-                    if (assetTableInfo.at(j).offset != assetInfo.offset) {
-                        assetSize = assetTableInfo.at(j).offset - assetInfo.offset;
-                        break;
-                    }
-                }
-            }
+            uint32_t assetSize = slotSize(assetInfo.offset);
 
             auto assetOffset = dataStartRomOffset + assetInfo.offset;
             BKAssetType assetType;
@@ -384,7 +393,7 @@ std::optional<std::shared_ptr<IParsedData>> BKAssetFactory::parse(std::vector<ui
                 continue;
             }
 
-            if (assetOffset + assetSize > buffer.size()) {
+            if (static_cast<uint64_t>(assetOffset) + assetSize > buffer.size()) {
                 SPDLOG_ERROR("Asset {} offset 0x{:X} + size 0x{:X} = 0x{:X} exceeds ROM "
                              "buffer 0x{:X}",
                              assetInfo.index, assetOffset, assetSize, assetOffset + assetSize, buffer.size());
@@ -397,7 +406,7 @@ std::optional<std::shared_ptr<IParsedData>> BKAssetFactory::parse(std::vector<ui
             if (romhackMode && assetSize > 0) {
                 const std::string& baselineHash = GetBaselineAssetHash(assetInfo.index);
                 if (!baselineHash.empty()) {
-                    if (assetOffset + assetSize <= rom.size()) {
+                    if (static_cast<uint64_t>(assetOffset) + assetSize <= rom.size()) {
                         sha1::SHA1 s;
                         s.processBytes(rom.data() + assetOffset, assetSize);
                         uint32_t digest[5];

--- a/src/factories/bk64/BKEmitText.h
+++ b/src/factories/bk64/BKEmitText.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cctype>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <yaml-cpp/yaml.h>
+
+namespace BK64 {
+
+// Emit a text string for modding yaml.
+inline void EmitText(YAML::Emitter& out, const std::string& str) {
+    const char* s = str.c_str();
+    bool plain = true;
+    for (const char* p = s; *p != '\0'; p++) {
+        if (static_cast<uint8_t>(*p) < 0x20 || static_cast<uint8_t>(*p) > 0x7E || *p == '\\') {
+            plain = false;
+            break;
+        }
+    }
+    if (plain) {
+        out << YAML::DoubleQuoted << s;
+        return;
+    }
+    std::string escaped;
+    for (const char* p = s; *p != '\0'; p++) {
+        const auto c = static_cast<uint8_t>(*p);
+        if (c == '\\') {
+            escaped += "\\\\";
+        } else if (c < 0x20 || c > 0x7E) {
+            char buf[5];
+            std::snprintf(buf, sizeof(buf), "\\x%02X", c);
+            escaped += buf;
+        } else {
+            escaped += static_cast<char>(c);
+        }
+    }
+    out << YAML::SingleQuoted << escaped;
+}
+
+// Reverse EmitText's escapes on a string read back from modding yaml.
+inline std::string DecodeText(const std::string& str) {
+    std::string out;
+    out.reserve(str.size());
+    for (size_t i = 0; i < str.size(); i++) {
+        if (str[i] == '\\' && i + 1 < str.size()) {
+            if (str[i + 1] == '\\') {
+                out += '\\';
+                i++;
+                continue;
+            }
+            if ((str[i + 1] == 'x' || str[i + 1] == 'X') && i + 3 < str.size() &&
+                std::isxdigit(static_cast<unsigned char>(str[i + 2])) &&
+                std::isxdigit(static_cast<unsigned char>(str[i + 3]))) {
+                out += static_cast<char>(std::stoi(str.substr(i + 2, 2), nullptr, 16));
+                i += 3;
+                continue;
+            }
+        }
+        out += str[i];
+    }
+    return out;
+}
+
+} // namespace BK64

--- a/src/factories/bk64/ConfigFactory.cpp
+++ b/src/factories/bk64/ConfigFactory.cpp
@@ -257,6 +257,10 @@ static constexpr uint32_t CUSTOM_CODE_RAM_BASE = 0x80400000;
 static constexpr uint32_t CUSTOM_CODE_RAM_END = 0x80800000;
 static constexpr uint32_t CUSTOM_CODE_RAW_MAX_SIZE = 0x100000; // raw-blob window before 0xFF trim
 static constexpr int CUSTOM_CODE_MIN_INTERNAL_JALS = 4;    // self-call threshold
+static constexpr uint32_t VANILLA_OVERLAY_SIZE = 902656;
+static constexpr uint32_t VANILLA_F37F90_OFFSET = 0xF37F90;
+static constexpr uint32_t VANILLA_CORE1_SIZE = 228336;
+static constexpr uint32_t VANILLA_CORE1_ROM_OFFSET = 0xF19250;
 
 static bool LooksLikeMipsFunctionPrologue(const uint8_t* p) {
     // addiu $sp, $sp, -N  ->  0x27 0xBD 0xFF 0xxx
@@ -329,6 +333,208 @@ static bool CheckCustomCodePayload(const std::vector<uint8_t>& payload, int& out
             outBlobSha1[i * 4 + 3] = digest[i] & 0xFF;
         }
     }
+    return true;
+}
+
+static void Sha1Into(const uint8_t* data, size_t len, uint8_t out[20]) {
+    sha1::SHA1 s;
+    s.processBytes(data, len);
+    uint32_t digest[5];
+    s.getDigest(digest);
+    for (int i = 0; i < 5; i++) {
+        out[i * 4 + 0] = (digest[i] >> 24) & 0xFF;
+        out[i * 4 + 1] = (digest[i] >> 16) & 0xFF;
+        out[i * 4 + 2] = (digest[i] >> 8) & 0xFF;
+        out[i * 4 + 3] = digest[i] & 0xFF;
+    }
+}
+
+// Collect j/jal targets landing in the custom-code RAM window from a decompressed overlay.
+static void CollectExtendedRamJumps(const uint8_t* ovl, uint32_t size, std::vector<uint32_t>& outTargets) {
+    for (uint32_t off = 0; off + 4 <= size; off += 4) {
+        uint32_t w = readBE32(ovl, off);
+        uint32_t op = w >> 26;
+        if (op != 2 && op != 3) {
+            continue;
+        }
+        uint32_t target = 0x80000000u | ((w & 0x03FFFFFFu) << 2);
+        if (target >= CUSTOM_CODE_RAM_BASE && target < CUSTOM_CODE_RAM_END) {
+            outTargets.push_back(target);
+        }
+    }
+}
+
+// Strategy 3: nothing in the 0x3F00000 window at all.
+static bool DetectOverlayHookedCustomCode(const std::vector<uint8_t>& rom, uint32_t& outBlobRomOffset,
+                                          int& outHookCount, uint32_t& outFirstTarget, uint32_t& outRamBase,
+                                          uint8_t outBlobSha1[20]) {
+    uint32_t ovlSize = 0, ovlAddr = 0;
+    uint8_t* ovl = FindPatchedOverlay(rom, ovlSize, ovlAddr);
+    if (ovl == nullptr) {
+        return false;
+    }
+    std::vector<uint32_t> targets;
+    // In-place-patch semantics only
+    if (ovlSize == VANILLA_OVERLAY_SIZE) {
+        CollectExtendedRamJumps(ovl, ovlSize, targets);
+    }
+    free(ovl);
+    if (ovlSize != VANILLA_OVERLAY_SIZE) {
+        return false;
+    }
+
+    // The booted core1 can carry hooks too. Prefer a relocated copy
+    // just before the booted core2; fall back to the vanilla slot.
+    uint32_t c1Addr = 0;
+    uint32_t scanStart = ovlAddr > 0x200000 ? ovlAddr - 0x200000 : 0;
+    for (uint32_t off = scanStart; off + 6 < ovlAddr; off += 4) {
+        if (rom[off] != 0x11 || rom[off + 1] != 0x72) {
+            continue;
+        }
+        if (readBE32(rom.data(), off + 2) == VANILLA_CORE1_SIZE) {
+            c1Addr = off; // keep the last hit (closest to core2)
+        }
+    }
+    if (c1Addr == 0 && VANILLA_CORE1_ROM_OFFSET + 6 < rom.size() && rom[VANILLA_CORE1_ROM_OFFSET] == 0x11 &&
+        rom[VANILLA_CORE1_ROM_OFFSET + 1] == 0x72) {
+        c1Addr = VANILLA_CORE1_ROM_OFFSET;
+    }
+    if (c1Addr != 0) {
+        try {
+            uint32_t sz = 0x100000;
+            uint8_t* c1 = bk_unzip(rom.data() + c1Addr, &sz);
+            if (c1) {
+                if (sz == VANILLA_CORE1_SIZE) {
+                    CollectExtendedRamJumps(c1, sz, targets);
+                }
+                free(c1);
+            }
+        } catch (...) {}
+    }
+
+    if (targets.size() < static_cast<size_t>(CUSTOM_CODE_MIN_INTERNAL_JALS)) {
+        return false;
+    }
+
+    uint32_t minTarget = *std::min_element(targets.begin(), targets.end());
+    uint32_t maxTarget = *std::max_element(targets.begin(), targets.end());
+    uint32_t ramBase = minTarget & ~0xFFFFFu;
+    uint32_t windowEnd = ramBase + 0x100000;
+
+    // Raw ROM words that jump inside the hook window = the blob calling itself.
+    // Cluster them; asset data yields sparse coincidental hits, the blob a dense run.
+    std::vector<uint32_t> hits;
+    for (uint32_t off = 0; off + 4 <= rom.size(); off += 4) {
+        uint32_t w = readBE32(rom.data(), off);
+        uint32_t op = w >> 26;
+        if (op != 2 && op != 3) {
+            continue;
+        }
+        uint32_t t = 0x80000000u | ((w & 0x03FFFFFFu) << 2);
+        if (t >= ramBase && t < windowEnd) {
+            hits.push_back(off);
+        }
+    }
+    std::vector<std::pair<uint32_t, uint32_t>> clusters; // index range into hits
+    for (uint32_t i = 0; i < hits.size(); i++) {
+        if (!clusters.empty() && hits[i] - hits[clusters.back().second] < 0x4000) {
+            clusters.back().second = i;
+        } else {
+            clusters.push_back({ i, i });
+        }
+    }
+    std::sort(clusters.begin(), clusters.end(),
+              [](const auto& a, const auto& b) { return (a.second - a.first) > (b.second - b.first); });
+
+    auto pageLive = [&rom](uint32_t p) {
+        if (p + 0x1000 > rom.size()) {
+            return false;
+        }
+        for (uint32_t i = 0; i < 0x1000; i++) {
+            uint8_t b = rom[p + i];
+            if (b != 0x00 && b != 0xFF) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    for (size_t c = 0; c < clusters.size() && c < 4; c++) {
+        // Page-expand the cluster to the full non-padding extent, trim trailing pad.
+        uint32_t start = hits[clusters[c].first] & ~0xFFFu;
+        while (start >= 0x1000 && pageLive(start - 0x1000)) {
+            start -= 0x1000;
+        }
+        uint32_t end = (hits[clusters[c].second] + 0xFFF) & ~0xFFFu;
+        while (end < rom.size() && pageLive(end)) {
+            end += 0x1000;
+        }
+        end = std::min<uint32_t>(end, static_cast<uint32_t>(rom.size()));
+        while (end > start && (rom[end - 1] == 0x00 || rom[end - 1] == 0xFF)) {
+            end--;
+        }
+        uint32_t len = end - start;
+        if (len < 0x100 || len > 0x200000) {
+            continue;
+        }
+        // The store must cover every hook target, and the targets must land on
+        // code rather than padding.
+        if (len < maxTarget - ramBase + 4) {
+            continue;
+        }
+        int live = 0;
+        for (uint32_t t : targets) {
+            uint32_t off = start + (t - ramBase);
+            if (off + 4 <= end && readBE32(rom.data(), off) != 0) {
+                live++;
+            }
+        }
+        if (live * 2 < static_cast<int>(targets.size())) {
+            continue;
+        }
+        bool prologue = false;
+        for (uint32_t off = start; off + 4 <= end && !prologue; off += 4) {
+            prologue = LooksLikeMipsFunctionPrologue(rom.data() + off);
+        }
+        if (!prologue) {
+            continue;
+        }
+
+        outBlobRomOffset = start;
+        outHookCount = static_cast<int>(targets.size());
+        outFirstTarget = minTarget;
+        outRamBase = ramBase;
+        if (outBlobSha1) {
+            Sha1Into(rom.data() + start, len, outBlobSha1);
+        }
+        SPDLOG_WARN("[ConfigFactory] Overlay-hooked custom code: {} overlay hooks into RAM 0x{:08X}+, raw blob "
+                    "at ROM 0x{:X} ({} bytes)",
+                    targets.size(), ramBase, start, len);
+        return true;
+    }
+
+    // Hooks exist but the store eluded the scan. Identify the hack by its sorted
+    // hook-target signature so the port still gets a stable id and the user still
+    // gets the custom-code warning.
+    std::sort(targets.begin(), targets.end());
+    std::vector<uint8_t> sig;
+    sig.reserve(targets.size() * 4);
+    for (uint32_t t : targets) {
+        sig.push_back((t >> 24) & 0xFF);
+        sig.push_back((t >> 16) & 0xFF);
+        sig.push_back((t >> 8) & 0xFF);
+        sig.push_back(t & 0xFF);
+    }
+    if (outBlobSha1) {
+        Sha1Into(sig.data(), sig.size(), outBlobSha1);
+    }
+    outBlobRomOffset = 0;
+    outHookCount = static_cast<int>(targets.size());
+    outFirstTarget = minTarget;
+    outRamBase = ramBase;
+    SPDLOG_WARN("[ConfigFactory] Overlay-hooked custom code: {} overlay hooks into RAM 0x{:08X}+ but no backing "
+                "blob located; identifying by hook signature",
+                targets.size(), ramBase);
     return true;
 }
 
@@ -405,14 +611,16 @@ static bool DetectCustomCodeBlob(const std::vector<uint8_t>& rom, uint32_t& outB
         }
     }
 
+    // Strategy 3: nothing in the standard window; look for hooks baked into the
+    // booted overlays and chase them to the store.
+    if (DetectOverlayHookedCustomCode(rom, outBlobRomOffset, outInternalJalCount, outFirstInternalTarget, outRamBase,
+                                      outBlobSha1)) {
+        outKind = CustomCodeKind::BB_INJECTED;
+        return true;
+    }
+
     return false;
 }
-
-// Decompressed size of the vanilla US rev0 F37F90 code overlay. BB's in-place
-// constant patching never changes it; a different size means the hack rebuilt
-// its code overlay (e.g. decomp-built) and every fixed overlay offset is invalid.
-static constexpr uint32_t VANILLA_OVERLAY_SIZE = 902656;
-static constexpr uint32_t VANILLA_F37F90_OFFSET = 0xF37F90;
 
 RomhackKind ClassifyRomhack(const std::vector<uint8_t>& rom) {
     if (rom.size() <= 0x1000000) {
@@ -924,9 +1132,15 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
     if (kind == RomhackKind::BBRomhack && rom.size() > FCF698_ROM_OFFSET + FCF698_SIZE) {
         const uint8_t* fcf = rom.data() + FCF698_ROM_OFFSET;
 
+        // A fully zeroed region means this build doesn't globalize the FCF698 data.
+        bool regionPresent = std::any_of(fcf, fcf + FCF698_SIZE, [](uint8_t b) { return b != 0; });
+        if (!regionPresent) {
+            SPDLOG_WARN("[ConfigFactory] FCF698 region is zeroed; skipping note door / jiggy puzzle sections");
+        }
+
         // Validate: first note door value should be a reasonable u16 (0-10000)
         uint16_t firstDoor = readBE16(fcf, FCF698_NOTE_DOORS_OFF);
-        if (firstDoor <= 10000) {
+        if (regionPresent && firstDoor <= 10000) {
             // Section 7: NOTE_DOORS
             {
                 size_t secPos = blob.beginSection(ConfigSectionType::NOTE_DOORS);
@@ -982,7 +1196,7 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
                     blob.data.resize(secPos - 2);
                 }
             }
-        } else {
+        } else if (regionPresent) {
             SPDLOG_WARN("[ConfigFactory] FCF698 validation failed: first door value "
                         "{} out of range",
                         firstDoor);

--- a/src/factories/bk64/ConfigFactory.cpp
+++ b/src/factories/bk64/ConfigFactory.cpp
@@ -428,15 +428,10 @@ RomhackKind ClassifyRomhack(const std::vector<uint8_t>& rom) {
     }
     free(ovl);
 
-    // The patched overlay's decompressed size matches vanilla exactly.
+    // A vanilla-sized overlay means BB's in-place patching, so fixed offsets are
+    // valid. Don't check where the blob lives; BB relocates it, and some builds
+    // reuse the freed 0xF37F90 region.
     if (ovlSize != VANILLA_OVERLAY_SIZE) {
-        return RomhackKind::CustomBuild;
-    }
-
-    // The vanilla sub-16MB region is intact.
-    if (rom.size() < VANILLA_F37F90_OFFSET + 6 || rom[VANILLA_F37F90_OFFSET] != 0x11 ||
-        rom[VANILLA_F37F90_OFFSET + 1] != 0x72 ||
-        readBE32(rom.data(), VANILLA_F37F90_OFFSET + 2) != VANILLA_OVERLAY_SIZE) {
         return RomhackKind::CustomBuild;
     }
 

--- a/src/factories/bk64/ConfigFactory.cpp
+++ b/src/factories/bk64/ConfigFactory.cpp
@@ -930,6 +930,7 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
             if (f9Size > 0x87B0 + 40) {
                 size_t secPos = blob.beginSection(ConfigSectionType::SKYBOX);
                 uint16_t count = 0;
+                std::vector<uint16_t> hackMaps;
 
                 for (uint32_t off = 0x87B0; off + 40 <= f9Size; off += 40) {
                     uint16_t sceneId = readBE16(modF9, off);
@@ -937,6 +938,7 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
                         break;
                     if (sceneId == 0)
                         continue;
+                    hackMaps.push_back(sceneId);
 
                     bool differs = memcmp(modF9 + off, vanF9 + off, 40) != 0;
                     if (differs) {
@@ -953,6 +955,28 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
                         SPDLOG_INFO("[ConfigFactory] skybox: scene 0x{:X} models [{},{},{}]", sceneId,
                                     readBE16(modF9, off + 4), readBE16(modF9, off + 16), readBE16(modF9, off + 28));
                     }
+                }
+
+                // A hack can also *remove* a map from the table (rekeying its slot to
+                // a new map). Diff-only emission would leave the port falling back
+                // to its built-in vanilla table and drawing a sky the hack deleted.
+                // An all-zero entry makes the runtime override resolve to "no skybox".
+                for (uint32_t off = 0x87B0; off + 40 <= f9Size; off += 40) {
+                    uint16_t vanId = readBE16(vanF9, off);
+                    if (vanId == 0 && off > 0x87B0 + 40)
+                        break;
+                    if (vanId == 0)
+                        continue;
+                    if (std::find(hackMaps.begin(), hackMaps.end(), vanId) != hackMaps.end())
+                        continue;
+                    blob.writeU16(vanId);
+                    for (int layer = 0; layer < 3; layer++) {
+                        blob.writeS16(0);
+                        blob.writeU32(0);
+                        blob.writeU32(0);
+                    }
+                    count++;
+                    SPDLOG_INFO("[ConfigFactory] skybox: scene 0x{:X} removed by hack -> none", vanId);
                 }
 
                 if (count > 0) {

--- a/src/factories/bk64/ConfigFactory.cpp
+++ b/src/factories/bk64/ConfigFactory.cpp
@@ -192,6 +192,32 @@ static constexpr uint32_t FCF698_SIZE = 9888;
 static constexpr uint32_t FCF698_NOTE_DOORS_OFF = 1996;
 static constexpr uint32_t FCF698_JIGGY_PUZZLES_OFF = 6984;
 
+// No-vanilla variant: find the warp stub's destination immediate in a single
+// overlay. Used when the hack overwrote its stock F9CAE0/F37F90 copies, so there
+// is nothing to diff against and every resolvable destination is emitted.
+static bool ScanWarpDestOnly(const uint8_t* ovl, uint32_t funcOff, uint32_t funcLen, uint32_t ovlSize, int& outDest) {
+    static const uint8_t kEpilogue[16] = {
+        0x8F, 0xBF, 0x00, 0x14, 0x27, 0xBD, 0x00, 0x18,
+        0x03, 0xE0, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00
+    };
+    outDest = -1;
+    uint32_t limit = std::min<uint32_t>(funcLen, 200);
+    if (funcOff + limit > ovlSize || limit < 20) {
+        return false;
+    }
+    const uint8_t* f = ovl + funcOff;
+    for (uint32_t i = 0; i + 20 <= limit; i += 4) {
+        if ((f[i] == 0x24 || f[i] == 0x34) && f[i + 1] == 0x05 && memcmp(f + i + 4, kEpilogue, 16) == 0) {
+            outDest = (f[i + 2] << 8) | f[i + 3];
+            return true;
+        }
+        if (f[i] == 0x03 && f[i + 1] == 0xE0 && f[i + 2] == 0x00 && f[i + 3] == 0x08) {
+            return false;
+        }
+    }
+    return false;
+}
+
 static bool ScanWarpDestDiff(const uint8_t* vanOvl, const uint8_t* modOvl, uint32_t funcOff, uint32_t funcLen,
                              uint32_t ovlSize, int& outVanDest, int& outModDest) {
     static const uint8_t kEpilogue[16] = {
@@ -825,8 +851,16 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
             } catch (...) {}
         }
 
-        if (modF9 && vanF9 && modSize == vanSize) {
+        // Some hacks relocate F9CAE0 and overwrite the stock copy,
+        // so there is no vanilla reference in the ROM to diff against.
+        const bool haveVanF9 = (vanF9 != nullptr && modSize == vanSize);
+        if (modF9 && (haveVanF9 || vanF9 == nullptr)) {
             uint32_t f9Size = modSize;
+            if (!haveVanF9) {
+                SPDLOG_WARN("[ConfigFactory] No vanilla F9CAE0 in this ROM (stock copy at 0x{:X} was overwritten); "
+                            "emitting all F9CAE0-derived entries instead of only differing ones.",
+                            VANILLA_F9CAE0);
+            }
 
             // Section 2: SCENE_REMAP (D_8036B810 at offset 0x8288)
             if (f9Size > 0x8288 + 155 * 8) {
@@ -841,8 +875,8 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
                         continue;
 
                     uint16_t modLevel = readBE16(modF9, off + 2);
-                    uint16_t vanLevel = readBE16(vanF9, off + 2);
-                    if (modLevel != vanLevel) {
+                    uint16_t vanLevel = haveVanF9 ? readBE16(vanF9, off + 2) : 0;
+                    if (!haveVanF9 || modLevel != vanLevel) {
                         blob.writeU16(mapId);
                         blob.writeU16(modLevel);
                         count++;
@@ -868,9 +902,9 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
                     uint32_t off = 0x8FD0 + i * 4;
                     uint16_t modMap = readBE16(modF9, off);
                     uint16_t modExit = readBE16(modF9, off + 2);
-                    uint16_t vanMap = readBE16(vanF9, off);
-                    uint16_t vanExit = readBE16(vanF9, off + 2);
-                    if (modMap != vanMap || modExit != vanExit) {
+                    uint16_t vanMap = haveVanF9 ? readBE16(vanF9, off) : 0;
+                    uint16_t vanExit = haveVanF9 ? readBE16(vanF9, off + 2) : 0;
+                    if (!haveVanF9 || modMap != vanMap || modExit != vanExit) {
                         blob.writeU8(static_cast<uint8_t>(i));
                         blob.writeU8(0); // pad
                         blob.writeU16(modMap);
@@ -902,7 +936,7 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
                     if (mapId == 0)
                         continue;
 
-                    bool differs = memcmp(modF9 + off, vanF9 + off, 8) != 0;
+                    bool differs = !haveVanF9 || memcmp(modF9 + off, vanF9 + off, 8) != 0;
                     if (differs) {
                         blob.writeU16(mapId);
                         blob.writeU16(readBE16(modF9, off + 2));
@@ -940,7 +974,7 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
                         continue;
                     hackMaps.push_back(sceneId);
 
-                    bool differs = memcmp(modF9 + off, vanF9 + off, 40) != 0;
+                    bool differs = !haveVanF9 || memcmp(modF9 + off, vanF9 + off, 40) != 0;
                     if (differs) {
                         blob.writeU16(sceneId);
                         // 3 layers: model (s16 LE), scale (f32 as u32 LE), rotation (f32 as
@@ -961,7 +995,7 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
                 // a new map). Diff-only emission would leave the port falling back
                 // to its built-in vanilla table and drawing a sky the hack deleted.
                 // An all-zero entry makes the runtime override resolve to "no skybox".
-                for (uint32_t off = 0x87B0; off + 40 <= f9Size; off += 40) {
+                for (uint32_t off = 0x87B0; haveVanF9 && off + 40 <= f9Size; off += 40) {
                     uint16_t vanId = readBE16(vanF9, off);
                     if (vanId == 0 && off > 0x87B0 + 40)
                         break;
@@ -1001,7 +1035,7 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
                     if (sceneId == 0)
                         continue;
 
-                    bool differs = memcmp(modF9 + off, vanF9 + off, 24) != 0;
+                    bool differs = !haveVanF9 || memcmp(modF9 + off, vanF9 + off, 24) != 0;
                     if (differs) {
                         blob.writeU16(sceneId);
                         blob.writeS16(static_cast<int16_t>(readBE16(modF9, off + 2))); // opa
@@ -1088,7 +1122,12 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
                     } catch (...) {}
                 }
 
-                if (vanOvl && f9Size > WARP_TABLE_OFF + WARP_ENTRY_COUNT * 4) {
+                // With a vanilla reference we emit only warps whose destination changed.
+                // Without one, the hack's own F9CAE0 still holds a valid warp function
+                // table pointing into its overlay, so resolve and emit them all.
+                const bool warpDiffMode = (haveVanF9 && vanOvl != nullptr);
+                const uint8_t* warpF9 = haveVanF9 ? vanF9 : modF9;
+                if ((warpDiffMode || !haveVanF9) && f9Size > WARP_TABLE_OFF + WARP_ENTRY_COUNT * 4) {
                     size_t secPos = blob.beginSection(ConfigSectionType::WARP_DESTINATIONS);
                     uint16_t count = 0;
 
@@ -1097,7 +1136,7 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
                     std::vector<uint32_t> funcOffs;
                     funcOffs.reserve(WARP_ENTRY_COUNT);
                     for (int w = 0; w < WARP_ENTRY_COUNT; w++) {
-                        uint32_t addr = readBE32(vanF9, WARP_TABLE_OFF + w * 4);
+                        uint32_t addr = readBE32(warpF9, WARP_TABLE_OFF + w * 4);
                         if (addr >= N64_OVL_BASE) {
                             funcOffs.push_back(addr - N64_OVL_BASE);
                         }
@@ -1105,10 +1144,10 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
                     std::sort(funcOffs.begin(), funcOffs.end());
                     funcOffs.erase(std::unique(funcOffs.begin(), funcOffs.end()), funcOffs.end());
 
-                    uint32_t scanSize = std::min(vanOvlSize, overlaySize);
+                    uint32_t scanSize = warpDiffMode ? std::min(vanOvlSize, overlaySize) : overlaySize;
                     for (int w = 0; w < WARP_ENTRY_COUNT; w++) {
                         uint32_t tOff = WARP_TABLE_OFF + w * 4;
-                        uint32_t addr = readBE32(vanF9, tOff);
+                        uint32_t addr = readBE32(warpF9, tOff);
                         if (addr < N64_OVL_BASE) {
                             continue;
                         }
@@ -1118,7 +1157,11 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
                         uint32_t funcLen = (next != funcOffs.end()) ? (*next - funcOff) : 200;
 
                         int vanDest = -1, modDest = -1;
-                        if (ScanWarpDestDiff(vanOvl, overlay, funcOff, funcLen, scanSize, vanDest, modDest)) {
+                        const bool emit = warpDiffMode
+                                              ? ScanWarpDestDiff(vanOvl, overlay, funcOff, funcLen, scanSize, vanDest,
+                                                                 modDest)
+                                              : ScanWarpDestOnly(overlay, funcOff, funcLen, scanSize, modDest);
+                        if (emit) {
                             blob.writeU16(static_cast<uint16_t>(w));
                             blob.writeU16(static_cast<uint16_t>(modDest));
                             count++;
@@ -1132,7 +1175,7 @@ std::vector<char> BuildGameConfigBlob(const std::vector<uint8_t>& rom, const std
                     } else {
                         blob.data.resize(secPos - 2);
                     }
-                } else if (!vanOvl) {
+                } else if (warpDiffMode && !vanOvl) {
                     SPDLOG_WARN("[ConfigFactory] Could not decompress vanilla F37F90 overlay for warp diff");
                 }
 

--- a/src/factories/bk64/DialogFactory.cpp
+++ b/src/factories/bk64/DialogFactory.cpp
@@ -1,5 +1,7 @@
 #include "DialogFactory.h"
 
+#include "BKEmitText.h"
+
 #include "Companion.h"
 #include "spdlog/spdlog.h"
 #include "types/RawBuffer.h"
@@ -142,7 +144,7 @@ ExportResult BK64::DialogModdingExporter::Export(std::ostream& write, std::share
         out << YAML::Flow;
         out << YAML::BeginSeq;
         out << YAML_HEX((uint32_t)cmd);
-        out << str.c_str();
+        EmitText(out, str);
         out << YAML::EndSeq;
     }
     out << YAML::EndSeq;
@@ -155,7 +157,7 @@ ExportResult BK64::DialogModdingExporter::Export(std::ostream& write, std::share
         out << YAML::Flow;
         out << YAML::BeginSeq;
         out << YAML_HEX((uint32_t)cmd);
-        out << str.c_str();
+        EmitText(out, str);
         out << YAML::EndSeq;
     }
     out << YAML::EndSeq;
@@ -313,7 +315,7 @@ std::optional<std::shared_ptr<IParsedData>> DialogFactory::parse_modding(std::ve
     for (YAML::iterator it = bottomNode.begin(); it != bottomNode.end(); ++it) {
         DialogString dialogString;
         dialogString.cmd = (*it)[0].as<uint32_t>();
-        dialogString.str = (*it)[1].as<std::string>();
+        dialogString.str = DecodeText((*it)[1].as<std::string>());
         dialogString.str += '\0';
         bottom.push_back(dialogString);
     }
@@ -321,7 +323,7 @@ std::optional<std::shared_ptr<IParsedData>> DialogFactory::parse_modding(std::ve
     for (YAML::iterator it = topNode.begin(); it != topNode.end(); ++it) {
         DialogString dialogString;
         dialogString.cmd = (*it)[0].as<uint32_t>();
-        dialogString.str = (*it)[1].as<std::string>();
+        dialogString.str = DecodeText((*it)[1].as<std::string>());
         dialogString.str += '\0';
         top.push_back(dialogString);
     }

--- a/src/factories/bk64/GruntyQuestionFactory.cpp
+++ b/src/factories/bk64/GruntyQuestionFactory.cpp
@@ -1,5 +1,7 @@
 #include "GruntyQuestionFactory.h"
 
+#include "BKEmitText.h"
+
 #include "Companion.h"
 #include "spdlog/spdlog.h"
 #include "types/RawBuffer.h"
@@ -138,7 +140,7 @@ ExportResult BK64::GruntyQuestionModdingExporter::Export(std::ostream& write, st
         out << YAML::Flow;
         out << YAML::BeginSeq;
         out << YAML_HEX((uint32_t)cmd);
-        out << str.c_str();
+        EmitText(out, str);
         out << YAML::EndSeq;
     }
     out << YAML::EndSeq;
@@ -153,7 +155,7 @@ ExportResult BK64::GruntyQuestionModdingExporter::Export(std::ostream& write, st
         out << YAML_HEX((uint32_t)cmd);
         out << YAML_HEX((uint32_t)unk0);
         out << YAML_HEX((uint32_t)unk1);
-        out << str.c_str();
+        EmitText(out, str);
         out << YAML::EndSeq;
     }
     out << YAML::EndSeq;
@@ -252,7 +254,7 @@ std::optional<std::shared_ptr<IParsedData>> GruntyQuestionFactory::parse_modding
     for (YAML::iterator it = textNode.begin(); it != textNode.end(); ++it) {
         DialogString dialogString;
         dialogString.cmd = (*it)[0].as<uint32_t>();
-        dialogString.str = (*it)[1].as<std::string>();
+        dialogString.str = DecodeText((*it)[1].as<std::string>());
         dialogString.str += '\0';
         text.push_back(dialogString);
     }
@@ -267,7 +269,7 @@ std::optional<std::shared_ptr<IParsedData>> GruntyQuestionFactory::parse_modding
         optionString.cmd = (*it)[0].as<uint32_t>();
         optionString.unk0 = (*it)[1].as<uint32_t>();
         optionString.unk1 = (*it)[2].as<uint32_t>();
-        optionString.str = (*it)[3].as<std::string>();
+        optionString.str = DecodeText((*it)[3].as<std::string>());
         optionString.str += '\0';
         options.push_back(optionString);
         i++;

--- a/src/factories/bk64/QuizQuestionFactory.cpp
+++ b/src/factories/bk64/QuizQuestionFactory.cpp
@@ -1,5 +1,7 @@
 #include "QuizQuestionFactory.h"
 
+#include "BKEmitText.h"
+
 #include "Companion.h"
 #include "spdlog/spdlog.h"
 #include "types/RawBuffer.h"
@@ -135,7 +137,7 @@ ExportResult BK64::QuizQuestionModdingExporter::Export(std::ostream& write, std:
         out << YAML::Flow;
         out << YAML::BeginSeq;
         out << YAML_HEX((uint32_t)cmd);
-        out << str.c_str();
+        EmitText(out, str);
         out << YAML::EndSeq;
     }
     out << YAML::EndSeq;
@@ -148,7 +150,9 @@ ExportResult BK64::QuizQuestionModdingExporter::Export(std::ostream& write, std:
         out << YAML::Flow;
         out << YAML::BeginSeq;
         out << YAML_HEX((uint32_t)cmd);
-        out << str.c_str();
+        out << YAML_HEX((uint32_t)static_cast<uint8_t>(str[0]));
+        out << YAML_HEX((uint32_t)static_cast<uint8_t>(str[1]));
+        EmitText(out, str.substr(2));
         out << YAML::EndSeq;
     }
     out << YAML::EndSeq;
@@ -244,7 +248,7 @@ std::optional<std::shared_ptr<IParsedData>> QuizQuestionFactory::parse_modding(s
     for (YAML::iterator it = textNode.begin(); it != textNode.end(); ++it) {
         DialogString dialogString;
         dialogString.cmd = (*it)[0].as<uint32_t>();
-        dialogString.str = (*it)[1].as<std::string>();
+        dialogString.str = DecodeText((*it)[1].as<std::string>());
         dialogString.str += '\0';
         text.push_back(dialogString);
     }
@@ -255,9 +259,14 @@ std::optional<std::shared_ptr<IParsedData>> QuizQuestionFactory::parse_modding(s
             SPDLOG_WARN("BK64 QuizQuestion: Only 3 Options Allowed; extra options ignored");
             break;
         }
+        if ((*it).size() != 4) {
+            throw std::runtime_error("BK64 QuizQuestion: option must be [cmd, 0xfd, 0x6c, \"text\"]");
+        }
         DialogString optionString;
         optionString.cmd = (*it)[0].as<uint32_t>();
-        optionString.str = (*it)[1].as<std::string>();
+        optionString.str.push_back(static_cast<char>((*it)[1].as<uint32_t>()));
+        optionString.str.push_back(static_cast<char>((*it)[2].as<uint32_t>()));
+        optionString.str += DecodeText((*it)[3].as<std::string>());
         optionString.str += '\0';
         options.push_back(optionString);
         i++;


### PR DESCRIPTION
ASan: `ci2raw` read `rawci[i]` for every pixel before the CI4 branch recomputed the index from packed nibbles. A CI4 buffer is only w*h/2 bytes, so the loop dead-read up to 2× past the allocation. Whether that faulted depended on heap page layout, so `torch modding export` segfaulted nondeterministically partway through the sprite/model textures.

BK Dialog: improved modding export formatting for easier editing of custom language packs

BK ConfigFactory: loosen romhack classification requirements so Lair Witch Project is properly detected as BBHack (verified no regression with Riverside Ruins which is built from the decomp)