### PR TITLE
Add support for reading offsets from an external file

### DIFF
--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -628,8 +628,9 @@ void Companion::ParseCurrentFileConfig(YAML::Node node, std::atomic<size_t>& ass
                 }
             } else {
                 throw std::runtime_error(
-                    "Incorrect yaml syntax for segments.\n\nThe yaml expects:\n:config:\n  segments:\n  - [<segment>, "
-                    "<file_offset>]\n\nLike so:\nsegments:\n  - [0x06, 0x821D10]");
+                "Incorrect yaml syntax for segments.\n\nThe yaml expects:\n:config:\n  segments:\n  - [<segment>, "
+                "<file_offset>] or - [<segment>, "
+                "<file_name>] \n\nLike so:\nsegments:\n  - [0x06, 0x821D10] or [0x06, object_jya_obj");
             }
         }
 
@@ -644,7 +645,8 @@ void Companion::ParseCurrentFileConfig(YAML::Node node, std::atomic<size_t>& ass
             } else {
                 throw std::runtime_error(
                     "Incorrect yaml syntax for segments.\n\nThe yaml expects:\n:config:\n  segments:\n  - [<segment>, "
-                    "<file_offset>]\n\nLike so:\nsegments:\n  - [0x06, 0x821D10]");
+                    "<file_offset>] or - [<segment>, "
+                    "<file_name>] \n\nLike so:\nsegments:\n  - [0x06, 0x821D10] or [0x06, object_jya_obj");
             }
         }
     }
@@ -1223,7 +1225,8 @@ void Companion::ProcessFile(YAML::Node root, std::atomic<size_t>& assetCount) {
             } else {
                 throw std::runtime_error(
                     "Incorrect yaml syntax for segments.\n\nThe yaml expects:\n:config:\n  segments:\n  - [<segment>, "
-                    "<file_offset>]\n\nLike so:\nsegments:\n  - [0x06, 0x821D10]");
+                    "<file_offset>] or - [<segment>, "
+                    "<file_name>] \n\nLike so:\nsegments:\n  - [0x06, 0x821D10] or [0x06, object_jya_obj");
             }
         }
     }

--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -1193,7 +1193,7 @@ void Companion::SetSegmentInfo(const YAML::Node& segments) {
 }
 
 uint32_t Companion::GetFileOffsetFromNodeStr(const std::string& str) const {
-    if (StringHelper::IsValidHex(str))
+    if (StringHelper::IsValidOffset(str))
         return strtoul(str.c_str(), nullptr, 16);
     return GetFileOffsetFromName(str);
 }

--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -620,8 +620,8 @@ void Companion::ParseCurrentFileConfig(YAML::Node node, std::atomic<size_t>& ass
         // Set global variables for segmented data
         if (segments.IsSequence() && segments.size()) {
             if (segments[0].IsSequence() && segments[0].size() == 2) {
-                gCurrentSegmentNumber = segments[0][0].as<uint32_t>();
-                gCurrentFileOffset = segments[0][1].as<uint32_t>();
+                SetSegmentInfo(segments);
+
                 gCurrentCompressionType = Decompressor::GetCompressionType(this->gRomData, gCurrentFileOffset);
                 if (node["no_compression"]) {
                     gCurrentCompressionType = CompressionType::None;
@@ -638,7 +638,7 @@ void Companion::ParseCurrentFileConfig(YAML::Node node, std::atomic<size_t>& ass
             auto segment = segments[i];
             if (segment.IsSequence() && segment.size() == 2) {
                 const auto id = segment[0].as<uint32_t>();
-                const auto replacement = segment[1].as<uint32_t>();
+                const auto replacement = GetFileOffsetFromNodeStr(segment[1].as<std::string>());
                 this->gConfig.segment.local[id] = replacement;
                 SPDLOG_DEBUG("Segment {} replaced with 0x{:X}", id, replacement);
             } else {
@@ -1183,6 +1183,19 @@ void Companion::ProcessExportFile() {
     }
 }
 
+void Companion::SetSegmentInfo(const YAML::Node& segments) {
+    gCurrentSegmentNumber = segments[0][0].as<uint32_t>();
+
+    const auto offsetNode = segments[0][1].as<std::string>();
+    gCurrentFileOffset = GetFileOffsetFromNodeStr(offsetNode);
+}
+
+uint32_t Companion::GetFileOffsetFromNodeStr(const std::string& str) const {
+    if (StringHelper::IsValidHex(str))
+        return strtoul(str.c_str(), nullptr, 16);
+    return GetFileOffsetFromName(str);
+}
+
 void Companion::ProcessFile(YAML::Node root, std::atomic<size_t>& assetCount) {
     // Reset per-file state so segment/offset settings from a previous file don't
     // bleed into this file's Phase 1 gAddrMap registration.
@@ -1201,8 +1214,8 @@ void Companion::ProcessFile(YAML::Node root, std::atomic<size_t>& assetCount) {
     if (auto segments = root[":config"]["segments"]) {
         if (segments.IsSequence() && segments.size() > 0) {
             if (segments[0].IsSequence() && segments[0].size() == 2) {
-                gCurrentSegmentNumber = segments[0][0].as<uint32_t>();
-                gCurrentFileOffset = segments[0][1].as<uint32_t>();
+                SetSegmentInfo(segments);
+
                 gCurrentCompressionType = Decompressor::GetCompressionType(this->gRomData, gCurrentFileOffset);
                 if (root[":config"]["no_compression"]) {
                     gCurrentCompressionType = CompressionType::None;
@@ -1234,9 +1247,14 @@ void Companion::ProcessFile(YAML::Node root, std::atomic<size_t>& assetCount) {
             continue;
         }
 
+        auto offset = GetFileOffsetFromNodeStr(node["offset"].as<std::string>());
+
         if (gCurrentSegmentNumber) {
-            if (IS_SEGMENTED(node["offset"].as<uint32_t>()) == false) {
-                node["offset"] = (gCurrentSegmentNumber << 24) | node["offset"].as<uint32_t>();
+
+            if (IS_SEGMENTED(offset) == false) {
+                offset = (gCurrentSegmentNumber << 24) | offset;
+                node["offset"] = offset;
+
             }
         }
 
@@ -1244,7 +1262,7 @@ void Companion::ProcessFile(YAML::Node root, std::atomic<size_t>& assetCount) {
             node["path"] = gCurrentVirtualPath;
         }
 
-        this->gAddrMap[this->gCurrentFile][node["offset"].as<uint32_t>()] = std::make_tuple(output, node);
+        this->gAddrMap[this->gCurrentFile][offset] = std::make_tuple(output, node);
     }
 
     // Stupid hack because the iteration broke the assets
@@ -1414,6 +1432,16 @@ void Companion::Process(std::atomic<size_t>& assetCount) {
         }
     }
     this->gAssetPath = (this->gSourceDirectory / rom["path"].as<std::string>()).string();
+
+    if (rom["filelist"]) {
+        const std::string filelistPath = (this->gSourceDirectory / rom["filelist"].as<std::string>()).string();
+        if (!fs::exists(filelistPath)) {
+            SPDLOG_ERROR("A filelist was specified but the file doesn't exist");
+            return;
+        }
+        ParseFilelist(filelistPath);
+    }
+
     auto opath = cfg["output"];
     auto gbi = cfg["gbi"];
     auto gbi_floats = cfg["gbi_floats"];
@@ -2589,4 +2617,17 @@ bool Companion::GetCompressedSegmentOffset(uint32_t* addr) {
         }
     }
     return false;
+}
+
+void Companion::ParseFilelist(const std::string& filelistPath) {
+    YAML::Node root = YAML::LoadFile(filelistPath);
+
+    for (const auto f : root["Files"]) {
+        for (const auto& kv : f) {
+            const auto file = kv.first.as<std::string>();
+            const auto offset = kv.second.as<uint32_t>();
+            gFileOffsets[file] = offset;
+        }
+
+    }
 }

--- a/src/Companion.h
+++ b/src/Companion.h
@@ -220,7 +220,6 @@ public:
     std::string GetCurrentFile(void) { return this->gCurrentFile; }
     std::optional<std::uint32_t> GetFileOffsetFromName(void) const { return this->gCurrentFileOffset; };
     std::uint32_t GetCurrSegmentNumber(void) const { return this->gCurrentSegmentNumber; };
-    std::uint32_t GetFileSegmentNumber(const std::string& file) const { return this->gFileSegMap.at(file); }
     CompressionType GetCurrCompressionType(void) const { return this->gCurrentCompressionType; };
     std::optional<std::uint32_t> GetCurrentCompressedSize(void) const { return this->gCurrentCompressedSize; };
     std::optional<VRAMEntry> GetCurrentVRAM(void) const { return this->gCurrentVram; };

--- a/src/Companion.h
+++ b/src/Companion.h
@@ -217,8 +217,10 @@ public:
     const std::vector<std::tuple<std::string, YAML::Node>>* GetNodesByTypeRef(const std::string& type, bool includeAutogen = false);
     std::string GetSymbolFromAddr(uint32_t addr, bool validZero = false);
 
-    std::optional<std::uint32_t> GetFileOffset(void) const { return this->gCurrentFileOffset; };
-    std::optional<std::uint32_t> GetCurrSegmentNumber(void) const { return this->gCurrentSegmentNumber; };
+    std::string GetCurrentFile(void) { return this->gCurrentFile; }
+    std::optional<std::uint32_t> GetFileOffsetFromName(void) const { return this->gCurrentFileOffset; };
+    std::uint32_t GetCurrSegmentNumber(void) const { return this->gCurrentSegmentNumber; };
+    std::uint32_t GetFileSegmentNumber(const std::string& file) const { return this->gFileSegMap.at(file); }
     CompressionType GetCurrCompressionType(void) const { return this->gCurrentCompressionType; };
     std::optional<std::uint32_t> GetCurrentCompressedSize(void) const { return this->gCurrentCompressedSize; };
     std::optional<VRAMEntry> GetCurrentVRAM(void) const { return this->gCurrentVram; };
@@ -253,6 +255,7 @@ public:
     bool GetCompressedSegmentOffset(uint32_t* addr);
 
     void SetSingleYMLPath(const std::string& path) { this->gSingleYMLPath = path; }
+    uint32_t GetFileOffsetFromName(const std::string& file) const { return this->gFileOffsets.at(file); }
 
 #ifdef BUILD_UI
     void RegisterUIFactory(const std::string& type, const std::shared_ptr<BaseFactoryUI>& factory);
@@ -301,6 +304,7 @@ private:
     std::vector<std::string> gCurrentExternalFiles;
     std::unordered_map<int, std::string> gManualSegments;
     std::unordered_set<std::string> gProcessedFiles;
+    std::unordered_map<std::string, uint32_t> gFileOffsets;
 
     std::unordered_map<std::string, std::vector<char>> gCompanionFiles;
     std::vector<std::pair<std::string, std::vector<char>>> gArchiveFiles;
@@ -341,4 +345,7 @@ private:
     void LoadYAMLRecursively(const std::string &dirPath, std::vector<YAML::Node> &result, bool skipRoot);
     std::vector<fs::directory_entry> GetAssetYMLs(YAML::Node& rom) const;
     std::optional<ParseResultData> ParseNode(YAML::Node& node, std::string& name);
+    void ParseFilelist(const std::string& filelistPath);
+    void SetSegmentInfo(const YAML::Node& segments);
+    uint32_t GetFileOffsetFromNodeStr(const std::string& str) const;
 };


### PR DESCRIPTION
Instead of YMLs for assets containing a hard coded rom address, support reading that address from an external file. This allows for de-duping YMLs using symlinks for multiple versions that have identical assets, but they are at different rom addresses.