### PR TITLE
Revert symlink support. Add actual support for out of tree YMLs

### DIFF
--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -1332,7 +1332,7 @@ std::vector<fs::directory_entry> Companion::GetAssetYMLs(YAML::Node& rom) const 
         single.emplace_back(a);
         return single;
     }
-    return Torch::getRecursiveEntries(this->gAssetPath, "");
+    return Torch::getRecursiveEntries(this->gAssetPath, this->gCommonAssetPath);
 }
 
 void Companion::Process(std::atomic<size_t>& assetCount) {

--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -544,13 +544,15 @@ void Companion::ParseCurrentFileConfig(YAML::Node node, std::atomic<size_t>& ass
                         " - <external_files>\n\ne.g.:\nexternal_files:\n  - actors/actor1.yaml");
                 }
 
-                std::string externalFileName =
-                    (this->gSourceDirectory / externalFile.as<std::string>()).generic_string();
-                if (StringHelper::StartsWith(
-                        std::filesystem::relative(externalFileName, this->gAssetPath).generic_string(), "../")) {
-                    throw std::runtime_error("External File " + externalFileName + " Not In Asset Directory " +
-                                             this->gAssetPath);
-                } else if (std::filesystem::relative(externalFileName, this->gAssetPath).string() == "") {
+                std::string externalFileName = (this->gSourceDirectory / externalFile.as<std::string>()).string();
+                const auto relPath = std::filesystem::relative(externalFileName, this->gAssetPath).string();
+                const auto relCommonPath = std::filesystem::relative(externalFileName, this->gCommonAssetPath).string();
+                if (StringHelper::StartsWith(relPath , "../")) {
+                    if (StringHelper::StartsWith(relCommonPath, "../"))
+                        throw std::runtime_error("External File " + externalFileName + " Not In Asset Directory " +
+                                                 this->gAssetPath);
+                }
+                if (relPath == "") {
                     throw std::runtime_error("External File " + externalFileName + " Not In Asset Directory " +
                                              this->gAssetPath);
                 }
@@ -869,6 +871,9 @@ void Companion::ProcessParseFile(YAML::Node root, std::atomic<size_t>& assetCoun
 
 void Companion::ProcessExportFile() {
     for (auto& result : this->gParseResults[this->gCurrentFile]) {
+        if (result.name.find("common") != std::string::npos) {
+            int bp = 0;
+        }
         std::ostringstream stream;
         ExportResult endptr = std::nullopt;
         WriteEntry wEntry;
@@ -1208,7 +1213,12 @@ void Companion::ProcessFile(YAML::Node root, std::atomic<size_t>& assetCount) {
     // directory must be resolved before the loop. Default to the file's own
     // path, then honor a :config directory override (used to register a room's
     // assets under its scene's directory).
-    this->gCurrentDirectory = relative(fs::path(this->gCurrentFile), this->gAssetPath).replace_extension("");
+    auto relPath = relative(fs::path(this->gCurrentFile), this->gAssetPath).replace_extension("");
+    if (StringHelper::StartsWith(relPath, "../"))
+        relPath = relative(fs::path(this->gCurrentFile), this->gCommonAssetPath).replace_extension("");
+
+    this->gCurrentDirectory = relPath;
+
     if (auto directory = root[":config"]["directory"]) {
         this->gCurrentDirectory = directory.as<std::string>();
     }
@@ -1325,7 +1335,7 @@ std::vector<fs::directory_entry> Companion::GetAssetYMLs(YAML::Node& rom) const 
         single.emplace_back(a);
         return single;
     }
-    return Torch::getRecursiveEntries(this->gAssetPath);
+    return Torch::getRecursiveEntries(this->gAssetPath, this->gCommonAssetPath);
 }
 
 void Companion::Process(std::atomic<size_t>& assetCount) {
@@ -1435,6 +1445,7 @@ void Companion::Process(std::atomic<size_t>& assetCount) {
         }
     }
     this->gAssetPath = (this->gSourceDirectory / rom["path"].as<std::string>()).string();
+    this->gCommonAssetPath = (this->gSourceDirectory / rom["common_path"].as<std::string>()).string();
 
     if (rom["filelist"]) {
         const std::string filelistPath = (this->gSourceDirectory / rom["filelist"].as<std::string>()).string();
@@ -1875,7 +1886,7 @@ void Companion::Pack(const std::string& folder, const std::string& output, const
     auto start = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
     std::unordered_map<std::string, std::vector<char>> files;
 
-    for (const auto& entry : Torch::getRecursiveEntries(folder)) {
+    for (const auto& entry : Torch::getRecursiveEntries(folder, "")) {
         if (entry.is_directory()) {
             continue;
         }

--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -533,49 +533,41 @@ void Companion::ParseCurrentFileConfig(YAML::Node node, std::atomic<size_t>& ass
         auto externalFiles = node["external_files"];
         if (externalFiles.IsSequence() && externalFiles.size()) {
             for (size_t i = 0; i < externalFiles.size(); i++) {
-                auto externalFileNode = externalFiles[i];
-                if (externalFileNode.size() == 0) {
+                auto externalFile = externalFiles[i];
+                if (externalFile.size() == 0) {
                     this->gCurrentExternalFiles.push_back(
-                        (this->gSourceDirectory / externalFileNode.as<std::string>()).generic_string());
+                        (this->gSourceDirectory / externalFile.as<std::string>()).generic_string());
                 } else {
-                    SPDLOG_INFO("External File size {}", externalFileNode.size());
+                    SPDLOG_INFO("External File size {}", externalFile.size());
                     throw std::runtime_error(
                         "Incorrect yaml syntax for external files.\n\nThe yaml expects:\n:config:\n  external_files:\n "
                         " - <external_files>\n\ne.g.:\nexternal_files:\n  - actors/actor1.yaml");
                 }
-                fs::path externalFileName;
-                std::string externalFile = externalFileNode.as<std::string>();
 
-                // ${ACTIVE_TREE} is used for symlinked YMLs that sit out of tree from the rest of the version folder. It will
-                // be resolved to the full path of where it would be if file wasn't symlinked
-                constexpr char symlinkTag[] = "${ACTIVE_TREE}";
-                const auto verTagPos = externalFile.find(symlinkTag);
-                if (verTagPos != std::string::npos) {
-                    externalFileName = externalFile.replace(verTagPos, sizeof(symlinkTag) - 1, this->gAssetPath);
-                } else {
-                    externalFileName = (this->gSourceDirectory / externalFile).generic_string();
-                }
-                const auto relativePath = externalFileName.lexically_relative(this->gAssetPath);
-                if (StringHelper::StartsWith(relativePath.generic_string(), "../")) {
-                    throw std::runtime_error("External File " + externalFileName.string() + " Not In Asset Directory " +
+                std::string externalFileName =
+                    (this->gSourceDirectory / externalFile.as<std::string>()).generic_string();
+                if (StringHelper::StartsWith(
+                        std::filesystem::relative(externalFileName, this->gAssetPath).generic_string(), "../")) {
+                    throw std::runtime_error("External File " + externalFileName + " Not In Asset Directory " +
                                              this->gAssetPath);
-                }
-                if (relativePath == "") {
-                    throw std::runtime_error("External File " + externalFileName.string() + " Not In Asset Directory " +
+                } else if (std::filesystem::relative(externalFileName, this->gAssetPath).string() == "") {
+                    throw std::runtime_error("External File " + externalFileName + " Not In Asset Directory " +
                                              this->gAssetPath);
                 }
 
-                if (!Torch::contains(this->gAddrMap, externalFileName.string())) {
-                    SPDLOG_INFO("Dependency on external file {}. Now processing {}", externalFileName.string(),
-                                externalFileName.string());
+                if (!Torch::contains(this->gAddrMap, externalFileName)) {
+                    SPDLOG_INFO("Dependency on external file {}. Now processing {}", externalFileName,
+                                externalFileName);
                     auto currentFile = this->gCurrentFile;
                     auto currentDirectory = this->gCurrentDirectory;
                     auto currentExternalFiles = this->gCurrentExternalFiles;
                     auto currentVirtualPath = this->gCurrentVirtualPath;
 
-                    this->gCurrentFile = externalFileName.string();
-                    this->gCurrentDirectory = externalFileName.lexically_relative(this->gAssetPath).replace_extension("");
-                    YAML::Node root = YAML::LoadFile(externalFileName.string());
+                    this->gCurrentFile = externalFileName;
+                    this->gCurrentDirectory =
+                        std::filesystem::relative(externalFileName, this->gAssetPath).replace_extension("");
+
+                    YAML::Node root = YAML::LoadFile(externalFileName);
 
                     if (!Torch::contains(this->gProcessedFiles, this->gCurrentFile)) {
                         ProcessFile(root, assetCount);
@@ -592,7 +584,7 @@ void Companion::ParseCurrentFileConfig(YAML::Node node, std::atomic<size_t>& ass
                     this->gCurrentVirtualPath = currentVirtualPath;
                     this->gFileHeader.clear();
                 } else {
-                    SPDLOG_INFO("Skipping external file {} as it has already been processed", externalFileName.string());
+                    SPDLOG_INFO("Skipping external file {} as it has already been processed", externalFileName);
                 }
             }
         }
@@ -1216,7 +1208,7 @@ void Companion::ProcessFile(YAML::Node root, std::atomic<size_t>& assetCount) {
     // directory must be resolved before the loop. Default to the file's own
     // path, then honor a :config directory override (used to register a room's
     // assets under its scene's directory).
-    this->gCurrentDirectory = fs::path(this->gCurrentFile).lexically_relative(this->gAssetPath).replace_extension("");
+    this->gCurrentDirectory = relative(fs::path(this->gCurrentFile), this->gAssetPath).replace_extension("");
     if (auto directory = root[":config"]["directory"]) {
         this->gCurrentDirectory = directory.as<std::string>();
     }

--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -1211,7 +1211,7 @@ void Companion::ProcessFile(YAML::Node root, std::atomic<size_t>& assetCount) {
     // path, then honor a :config directory override (used to register a room's
     // assets under its scene's directory).
     auto relPath = relative(fs::path(this->gCurrentFile), this->gAssetPath).replace_extension("");
-    if (StringHelper::StartsWith(relPath, "../"))
+    if (StringHelper::StartsWith(relPath.string(), "../"))
         relPath = relative(fs::path(this->gCurrentFile), this->gCommonAssetPath).replace_extension("");
 
     this->gCurrentDirectory = relPath;

--- a/src/Companion.cpp
+++ b/src/Companion.cpp
@@ -871,9 +871,6 @@ void Companion::ProcessParseFile(YAML::Node root, std::atomic<size_t>& assetCoun
 
 void Companion::ProcessExportFile() {
     for (auto& result : this->gParseResults[this->gCurrentFile]) {
-        if (result.name.find("common") != std::string::npos) {
-            int bp = 0;
-        }
         std::ostringstream stream;
         ExportResult endptr = std::nullopt;
         WriteEntry wEntry;
@@ -1335,7 +1332,7 @@ std::vector<fs::directory_entry> Companion::GetAssetYMLs(YAML::Node& rom) const 
         single.emplace_back(a);
         return single;
     }
-    return Torch::getRecursiveEntries(this->gAssetPath, this->gCommonAssetPath);
+    return Torch::getRecursiveEntries(this->gAssetPath, "");
 }
 
 void Companion::Process(std::atomic<size_t>& assetCount) {

--- a/src/Companion.h
+++ b/src/Companion.h
@@ -269,6 +269,7 @@ private:
     fs::path gCurrentDirectory;
     std::string gCurrentHash;
     std::string gAssetPath;
+    std::string gCommonAssetPath;
     std::string gVersion;
     std::string gSingleYMLPath;
     std::vector<uint8_t> gRomData;

--- a/src/utils/TorchUtils.cpp
+++ b/src/utils/TorchUtils.cpp
@@ -35,10 +35,14 @@ int getFileDepth(const fs::path& base, const fs::path& p) {
     return std::distance(base.begin(), p.begin());
 }
 
-std::vector<fs::directory_entry> Torch::getRecursiveEntries(const fs::path baseDir) {
+std::vector<fs::directory_entry> Torch::getRecursiveEntries(const fs::path baseDir, const fs::path commonDir) {
     std::set<fs::directory_entry> result;
 
     for (const auto& entry : fs::recursive_directory_iterator(baseDir)) {
+        result.insert(entry);
+    }
+
+    for (const auto& entry : fs::recursive_directory_iterator(commonDir, std::filesystem::directory_options::follow_directory_symlink)) {
         result.insert(entry);
     }
 

--- a/src/utils/TorchUtils.cpp
+++ b/src/utils/TorchUtils.cpp
@@ -38,7 +38,7 @@ int getFileDepth(const fs::path& base, const fs::path& p) {
 std::vector<fs::directory_entry> Torch::getRecursiveEntries(const fs::path baseDir) {
     std::set<fs::directory_entry> result;
 
-    for (const auto& entry : fs::recursive_directory_iterator(baseDir, std::filesystem::directory_options::follow_directory_symlink)) {
+    for (const auto& entry : fs::recursive_directory_iterator(baseDir)) {
         result.insert(entry);
     }
 

--- a/src/utils/TorchUtils.cpp
+++ b/src/utils/TorchUtils.cpp
@@ -42,8 +42,10 @@ std::vector<fs::directory_entry> Torch::getRecursiveEntries(const fs::path baseD
         result.insert(entry);
     }
 
-    for (const auto& entry : fs::recursive_directory_iterator(commonDir, std::filesystem::directory_options::follow_directory_symlink)) {
-        result.insert(entry);
+    if (!commonDir.empty()) {
+        for (const auto& entry : fs::recursive_directory_iterator(commonDir)) {
+            result.insert(entry);
+        }
     }
 
     std::vector<fs::directory_entry> sortedEntries(result.begin(), result.end());

--- a/src/utils/TorchUtils.h
+++ b/src/utils/TorchUtils.h
@@ -34,6 +34,6 @@ constexpr bool contains(const Container& c, const Key& k) {
 }
 
 uint32_t translate(uint32_t offset);
-std::vector<std::filesystem::directory_entry> getRecursiveEntries(const std::filesystem::path baseDir);
+std::vector<std::filesystem::directory_entry> getRecursiveEntries(const std::filesystem::path baseDir, const std::filesystem::path );
 
 };


### PR DESCRIPTION
it turns out Windows really doesn't like symlinks. It does support them but there a lot of hoops to jump through none of which are reasonable for the end user.